### PR TITLE
feat: 支持查看详情

### DIFF
--- a/components/FriendsMemo.vue
+++ b/components/FriendsMemo.vue
@@ -2,10 +2,10 @@
 
   <div class="memo flex flex-row gap-2 sm:gap-4 text-sm border-x-0 pt-2 p-2 sm:p-4"
     :class="{ 'bg-slate-100 dark:bg-neutral-800': props.memo.pinned }">
-    <img :src="props.memo.user.avatarUrl" class="avatar w-9 h-9 rounded" />
+    <img :src="props.memo.user.avatarUrl" class="avatar w-9 h-9 rounded" @click="toDetail" />
     <div class="flex flex-col gap-.5 flex-1">
       <div class="flex flex-row justify-between items-center">
-        <div class="username text-[#576b95] cursor-default mb-1 dark:text-white">{{ props.memo.user.nickname }}</div>
+        <div class="username text-[#576b95] cursor-default mb-1 dark:text-white" @click="toDetail">{{ props.memo.user.nickname }}</div>
         <Pin :size=14 v-if="props.memo.pinned" />
       </div>
       <div class="memo-content text-sm friend-md" ref="el" v-html="props.memo.content.replaceAll(/\n/g, '<br/>')">
@@ -116,8 +116,7 @@
               <Comment :comment="comment" @memo-update="refreshComment" :index="index"
                 @comment-started="momentsShowCommentInput = false" />
             </div>
-            <div v-if="props.memo._count.comments > 5 && props.showMore" class="text-[#576b95] cursor-pointer"
-              @click="navigateTo(`/detail/${props.memo.id}`)">查看更多...</div>
+            <div v-if="props.memo._count.comments > 5 && props.showMore" class="text-[#576b95] cursor-pointer" @click="toDetail">查看更多...</div>
           </div>
         </template>
       </div>
@@ -216,6 +215,10 @@ const like = async () => {
     }
     emit('memo-update')
   }
+}
+
+const toDetail = () => {
+  if (props.showMore) navigateTo(`/detail/${props.memo.id}`);
 }
 
 const pinned = async () => {


### PR DESCRIPTION
需求：当想给朋友分享具体的某一条朋友圈记录时，能准确进入这条记录
现状：现在只能在列表页面查找，目前查看详情只能在评论数过多的时候才能进入到详情
解决方案：点击头像和昵称，可以进入这条朋友圈详情