### PR TITLE
细节优化及调整

### DIFF
--- a/front/components/DoubanEdit.vue
+++ b/front/components/DoubanEdit.vue
@@ -1,6 +1,6 @@
 <template>
   <UPopover :ui="{base:'w-[300px]'}" :popper="{ arrow: true }" mode="click">
-    <svg class="focus:outline-0 cursor-pointer w-10 h-10 sm:w-6 sm:h-6" xmlns="http://www.w3.org/2000/svg"
+    <svg class="focus:outline-0 cursor-pointer w-6 h-6" xmlns="http://www.w3.org/2000/svg"
          viewBox="0 0 24 24" fill="currentColor" data-state="closed">
       <path
           d="M15.2735 15H5V7H19V15H17.3764L16.0767 19H21V21H3V19H7.6123L6.8 16.5L8.70211 15.882L9.71522 19H13.9738L15.2735 15ZM3.5 3H20.5V5H3.5V3ZM7 9V13H17V9H7Z"

--- a/front/components/ExternalUrl.vue
+++ b/front/components/ExternalUrl.vue
@@ -1,6 +1,6 @@
 <template>
   <UPopover :popper="{ arrow: true }" mode="click">
-    <UIcon name="i-carbon-link" class="w-10 h-10 sm:w-6 sm:h-6"/>
+    <UIcon name="i-carbon-link" class="w-6 h-6"/>
     <template #panel="{close}">
       <div class="p-4 flex flex-col gap-2">
         <UInput v-model="url" placeholder="请输入分享的链接"/>

--- a/front/components/Memo.vue
+++ b/front/components/Memo.vue
@@ -72,22 +72,22 @@
           <div ref="toolbarRef" v-if="showToolbar"
                class="absolute top-[-8px] right-[32px] bg-[#4c4c4c] rounded text-white p-2 px-4">
             <div class="flex flex-row gap-2">
-              <template v-if="global.userinfo.id === 1">
-                <div class="flex flex-row gap-1 cursor-pointer items-center" @click="setPinned(item.id)">
-                  <UIcon name="i-carbon-pin"/>
-                  <div class="hidden sm:block">{{ item.pinned ? '取消' : '' }}置顶</div>
-                </div>
-                <span class="bg-[#6b7280] h-[20px] w-[1px]"></span>
-              </template>
               <div class="flex flex-row gap-1 cursor-pointer items-center" @click="likeMemo(item.id)">
                 <UIcon name="i-carbon-favorite" :class="[liked ? 'text-red-400' : '']"/>
-                <div class="hidden sm:block">赞</div>
+                <div>赞</div>
               </div>
               <template v-if="sysConfig.enableComment">
                 <span class="bg-[#6b7280] h-[20px] w-[1px]"></span>
                 <div class="flex flex-row gap-1 cursor-pointer items-center" @click="doComment">
                   <UIcon name="i-carbon-chat"/>
-                  <div class="hidden sm:block">评论</div>
+                  <div>评论</div>
+                </div>
+              </template>
+              <template v-if="global.userinfo.id === 1">
+                <span class="bg-[#6b7280] h-[20px] w-[1px]"></span>
+                <div class="flex flex-row gap-1 cursor-pointer items-center" @click="setPinned(item.id)">
+                  <UIcon name="i-carbon-pin"/>
+                  <div class="hidden sm:block">{{ item.pinned ? '取消' : '' }}置顶</div>
                 </div>
               </template>
               <template v-if="global&&global.userinfo.id === item.userId">

--- a/front/components/MemoEdit.vue
+++ b/front/components/MemoEdit.vue
@@ -8,6 +8,7 @@
       <music v-bind="state.music" @confirm="updateMusic"/>
       <upload-video @confirm="handleVideo" v-bind="state.video"/>
       <douban-edit v-model:type="doubanType" v-model:data="doubanData"/>
+      <UIcon name="i-carbon-text-clear-format" @click="reset" class="w-6 h-6 cursor-pointer" title="清空"></UIcon>
     </div>
 
     <div class="w-full" @contextmenu.prevent="onContextMenu">
@@ -30,17 +31,6 @@
       </UContextMenu>
     </div>
 
-    <div class="flex flex-col gap-2">
-      <external-url-preview :favicon="state.externalFavicon" :title="state.externalTitle" :url="state.externalUrl"/>
-      <upload-image-preview :imgs="state.imgs" @remove-image="handleRemoveImage" @drag-image="handleDragImage"/>
-      <music-preview v-if="state.music && state.music.id && state.music.type && state.music.server"
-                     v-bind="state.music"/>
-      <douban-book-preview :book="doubanData" v-if="doubanType === 'book' && doubanData&& doubanData.title"/>
-      <douban-movie-preview :movie="doubanData" v-if="doubanType === 'movie' && doubanData&& doubanData.title"/>
-      <youtube-preview v-if="state.video.type === 'youtube' && state.video.value" :url="state.video.value"/>
-      <bilibili-preview v-if="state.video.type === 'bilibili' && state.video.value" :url="state.video.value"/>
-      <video-preview v-if="state.video.type === 'online' && state.video.value" :url="state.video.value"/>
-    </div>
     <div class="flex justify-between items-center">
       <div class="flex flex-row gap-1 items-center text-[#576b95] text-sm cursor-pointer">
         <UPopover :popper="{ arrow: true }" mode="click">
@@ -66,11 +56,22 @@
         </div>
 
         <UButtonGroup>
-          <UButton @click="saveMemo">发表</UButton>
-          <UButton color="white" @click="reset">清空</UButton>
           <UButton color="gray" variant="solid" @click="navigateTo('/')">返回</UButton>
+          <UButton @click="saveMemo">发表</UButton>
         </UButtonGroup>
       </div>
+    </div>
+    
+    <div class="flex flex-col gap-2">
+      <external-url-preview :favicon="state.externalFavicon" :title="state.externalTitle" :url="state.externalUrl"/>
+      <upload-image-preview :imgs="state.imgs" @remove-image="handleRemoveImage" @drag-image="handleDragImage"/>
+      <music-preview v-if="state.music && state.music.id && state.music.type && state.music.server"
+                     v-bind="state.music"/>
+      <douban-book-preview :book="doubanData" v-if="doubanType === 'book' && doubanData&& doubanData.title"/>
+      <douban-movie-preview :movie="doubanData" v-if="doubanType === 'movie' && doubanData&& doubanData.title"/>
+      <youtube-preview v-if="state.video.type === 'youtube' && state.video.value" :url="state.video.value"/>
+      <bilibili-preview v-if="state.video.type === 'bilibili' && state.video.value" :url="state.video.value"/>
+      <video-preview v-if="state.video.type === 'online' && state.video.value" :url="state.video.value"/>
     </div>
   </div>
 

--- a/front/components/Music.vue
+++ b/front/components/Music.vue
@@ -1,6 +1,6 @@
 <template>
   <UPopover :ui="{base:'w-[350px] min-h-[350px]'}" :popper="{ arrow: true }" mode="click">
-    <UIcon name="i-carbon-music" class="cursor-pointer w-10 h-10 sm:w-6 sm:h-6"/>
+    <UIcon name="i-carbon-music" class="cursor-pointer w-6 h-6"/>
     <template #panel="{close}">
       <div class="p-4 flex flex-col gap-2 max-h-[400px] overflow-auto">
         <div class="text-xs text-gray-400">嵌入在线音乐</div>

--- a/front/components/UploadImage.vue
+++ b/front/components/UploadImage.vue
@@ -1,6 +1,6 @@
 <template>
   <UPopover :popper="{ arrow: true }" mode="click">
-    <UIcon name="i-carbon-image" class="cursor-pointer w-10 h-10 sm:w-6 sm:h-6"/>
+    <UIcon name="i-carbon-image" class="cursor-pointer w-6 h-6"/>
     <template #panel="{close}">
       <div class="p-4 flex flex-col gap-2">
         <div class="text-xs text-gray-400">本地上传</div>

--- a/front/components/UploadVideo.vue
+++ b/front/components/UploadVideo.vue
@@ -1,6 +1,6 @@
 <template>
   <UPopover :ui="{base:'w-[300px]'}" :popper="{ arrow: true }" mode="click">
-    <UIcon name="i-carbon-video-player" class="cursor-pointer w-10 h-10 sm:w-6 sm:h-6"/>
+    <UIcon name="i-carbon-video-player" class="cursor-pointer w-6 h-6"/>
     <template #panel="{close}">
       <div class="p-4 flex flex-col gap-2">
         <div class="text-xs text-gray-400">嵌入b站视频</div>

--- a/front/layouts/default.vue
+++ b/front/layouts/default.vue
@@ -6,7 +6,7 @@
 
   <div title="到顶部" v-if="y>200 && $route.path === '/'"
        class="hidden sm:block bottom-[20%] sm:right-[20%] md:right-[10%] lg:right-[15%] xl:right-[20%] 2xl:right-[28%] fixed  flex items-center justify-center">
-    <UIcon name="i-carbon-up-to-top" class="w-12 h-12 text-gray-500 cursor-pointer" @click="y=0"></UIcon>
+    <UIcon name="i-carbon-up-to-top" class="w-10 h-10 text-gray-500 cursor-pointer" @click="y=0"></UIcon>
   </div>
 
 
@@ -15,12 +15,15 @@
          v-if="global.userinfo.token && $route.path === '/'">
       <div class="flex flex-col items-center gap-2">
         <div v-if="y>300" @click="y=0"
-             class="mr-4 rounded-full bg-slate-50 w-14 h-14 flex items-center justify-center shadow-xl">
-          <UIcon name="i-carbon-up-to-top" class="w-8 h-8 text-[#9fc84a]"></UIcon>
+             class="dark:bg-gray-900/85 mr-4 rounded-full bg-slate-50 w-10 h-10 flex items-center justify-center shadow-xl">
+          <UIcon name="i-carbon-up-to-top" class="w-6 h-6 text-[#9fc84a] cursor-pointer"></UIcon>
         </div>
-        <NuxtLink to="/new" class="mr-4 rounded-full bg-slate-50 w-14 h-14 flex items-center justify-center shadow-xl">
-          <UIcon name="i-carbon-edit" class="w-8 h-8 text-[#9fc84a]"></UIcon>
+        <NuxtLink to="/new" class="dark:bg-gray-900/85 mr-4 rounded-full bg-slate-50 w-10 h-10 flex items-center justify-center shadow-xl">
+          <UIcon name="i-carbon-edit" class="w-6 h-6 text-[#9fc84a]"></UIcon>
         </NuxtLink>
+        <div class="dark:bg-gray-900/85 mr-4 rounded-full bg-slate-50 w-10 h-10 flex items-center justify-center shadow-xl" @click="open = true">
+          <UIcon name="i-carbon-overflow-menu-horizontal" class="w-6 h-6 text-[#9fc84a] cursor-pointer"></UIcon>
+        </div>
       </div>
     </div>
 
@@ -28,25 +31,15 @@
          v-if="!global.userinfo.token && $route.path === '/'">
       <div class="flex flex-col items-center gap-2">
         <div v-if="y>300" @click="y=0"
-             class="mr-4 rounded-full bg-slate-50 w-14 h-14 flex items-center justify-center shadow-xl">
-          <UIcon name="i-carbon-up-to-top" class="w-8 h-8 text-[#9fc84a]"></UIcon>
+             class="dark:bg-gray-900/85 mr-4 rounded-full bg-slate-50 w-10 h-10 flex items-center justify-center shadow-xl">
+          <UIcon name="i-carbon-up-to-top" class="w-6 h-6 text-[#9fc84a] cursor-pointer"></UIcon>
         </div>
         <NuxtLink to="/user/login"
-                  class="mr-4 rounded-full bg-slate-50 w-14 h-14 flex items-center justify-center shadow-xl">
-          <UIcon name="i-carbon-login" class="w-8 h-8 text-[#9fc84a]"></UIcon>
+                  class="dark:bg-gray-900/85 mr-4 rounded-full bg-slate-50 w-10 h-10 flex items-center justify-center shadow-xl">
+          <UIcon name="i-carbon-login" class="w-6 h-6 text-[#9fc84a]"></UIcon>
         </NuxtLink>
       </div>
     </div>
-
-
-    <div class="right-2 top-2 w-full fixed  flex items-center justify-end" v-if="global.userinfo.token">
-      <div class="flex flex-col items-center gap-2">
-        <div class="flex rounded bg-slate-50 p-1 gap-2 items-center justify-center shadow-xl" @click="open = true">
-          <UIcon name="i-carbon-settings" class="w-4 h-4 text-[#9fc84a]"></UIcon>
-        </div>
-      </div>
-    </div>
-
 
     <MobileNav :open="open"/>
   </div>


### PR DESCRIPTION
- 页面图标大小优化，并适配黑夜模式
- 调整移动端侧边栏图标到右下角与到顶部图标一起
- 调整发表与编辑页面的预览区域到提交按钮的下方，清空调整到工具栏用图标代替
![1723785842305](https://github.com/user-attachments/assets/4954541e-d023-48e6-959c-d57e26bf140d)
![1723785922506](https://github.com/user-attachments/assets/c4732f15-22a4-4201-a672-156194e91773)
