### PR TITLE
禁止自动缩放

### DIFF
--- a/front/nuxt.config.ts
+++ b/front/nuxt.config.ts
@@ -24,6 +24,10 @@ export default defineNuxtConfig({
     },
     app: {
         head: {
+            meta: [
+                { name: "viewport", content: "width=device-width, initial-scale=1, user-scalable=no" },
+                { charset: "utf-8" },
+            ],
             link: [
                 {href: `/css/APlayer.min.css`, rel: 'stylesheet'},
             ],


### PR DESCRIPTION
iOS 中点击输入框时会自动调整页面缩放比例，可能会影响页面浏览，fix #177 