### PR TITLE
fix: 允许清空已填写的内容

### DIFF
--- a/backend/handler/memo.go
+++ b/backend/handler/memo.go
@@ -376,15 +376,7 @@ func (m MemoHandler) SaveMemo(c echo.Context) error {
 	memo.ShowType = req.ShowType
 
 	m.base.log.Info().Msgf("memo is %+v", memo)
-
-	if req.ID > 0 {
-		if memo.Tags == nil || *memo.Tags == "" {
-			m.base.db.Select("tags").Updates(&memo)
-		}
-		m.base.db.Updates(&memo)
-	} else {
-		m.base.db.Save(&memo)
-	}
+	m.base.db.Save(&memo)
 
 	return SuccessResp(c, h{})
 }


### PR DESCRIPTION
代码中使用 req.ID 来判断当前的 memo 是否已经存在：
1. 若存在，则使用 Updates 方法进行更新，并且额外处理了 memo.Tags 为空的场景
2. 若不存在，则使用 Save 方法进行创建

以上逻辑会导致已经创建的 memo 无法清空某些内容，如：
1. 分享的链接
2. 上传的图片
3. 其他附加内容

实际上，根据 [gorm 文档](https://gorm.io/docs/update.html) 描述：Save is a combination function. If save value does not contain primary key, it will execute Create, otherwise it will execute Update (with all fields).

所以直接使用 Save 方法即可达到：
1. memo 不存在（主键 ID 查询不到）时，创建新的 memo
2. memo 存在（主键 ID 可查询到）时，更新已有的 memo，更新操作会包含空值
