### PR TITLE
修复 swagger 页面无法打开

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -72,10 +72,12 @@ func main() {
 	setupRouter(injector)
 
 	migrateTo3(tx, myLogger)
+
 	e.HideBanner = true
-	myLogger.Info().Msgf("服务端启动成功,监听:%d端口...", cfg.Port)
 	err = e.Start(fmt.Sprintf(":%d", cfg.Port))
-	if err != nil {
+	if err == nil {
+		myLogger.Info().Msgf("服务端启动成功,监听:%d端口...", cfg.Port)
+	} else {
 		myLogger.Fatal().Msgf("服务启动失败,错误原因:%s", err)
 	}
 }

--- a/front/nuxt.config.ts
+++ b/front/nuxt.config.ts
@@ -49,7 +49,11 @@ export default defineNuxtConfig({
                 "/upload": {
                     target: "http://localhost:37892",
                     changeOrigin: true,
-                }
+                },
+                "/swagger": {
+                    target: "http://localhost:37892",
+                    changeOrigin: true,
+                },
             },
         },
         build: {


### PR DESCRIPTION
<!--

在创建 PR 前，请务必在右侧的 Labels 选项中添加以下 Label 中的一个:
- doc: 当前 PR 更新了文档
- bugfix: 当前 PR 修复了 bug
- feature: 当前 PR 添加了新功能
以便于自动生成 Release 时自动对 PR 进行归类。

在选择 Label 后，请在下方标题后填写当前 PR 的详细描述。

-->

### 这个 PR 做了什么？

fix #210 

1. 修复 release 版本无法打开 swagger 页面
2. 开发模式同时允许通过默认的 前端端口 `:3000` 和 后端端口 `:37892` 访问 swagger
