### PR TITLE
修复文件路径穿越漏洞

### DIFF
--- a/backend/handler/file.go
+++ b/backend/handler/file.go
@@ -32,18 +32,6 @@ func NewFileHandler(injector do.Injector) *FileHandler {
 	return &FileHandler{do.MustInvoke[BaseHandler](injector)}
 }
 
-func (f FileHandler) Get(c echo.Context) error {
-	filename := c.Param("filename")
-	if filename == "" {
-		return c.HTML(404, "not found")
-	}
-	fp := path.Join(f.base.cfg.UploadDir, filename)
-	if _, err := os.Stat(fp); errors.Is(err, os.ErrNotExist) {
-		return c.HTML(404, "not found")
-	}
-	return c.File(path.Join(f.base.cfg.UploadDir, filename))
-}
-
 // Upload godoc
 //
 //	@Tags		File
@@ -99,7 +87,7 @@ func (f FileHandler) Upload(c echo.Context) error {
 		if err := CompressImage(f, img_filepath, thumb_filepath, 30); err != nil {
 			f.base.log.Error().Msgf("压缩图片异常:%s", err)
 		}
-		
+
 		result = append(result, "/upload/"+img_filename)
 	}
 	return SuccessResp(c, result)

--- a/backend/main_prod.go
+++ b/backend/main_prod.go
@@ -79,15 +79,13 @@ func main() {
 	setupRouter(injector)
 
 	e.Use(middleware.StaticWithConfig(middleware.StaticConfig{
+		Root:       "public",
 		HTML5:      true,
-		Root:       "public", // because files are located in `web` directory in `webAssets` fs
+		IgnoreBase: false,
+		Browse:     false,
 		Filesystem: http.FS(staticFiles),
 		Skipper: func(c echo.Context) bool {
-			if strings.HasPrefix(c.Request().URL.Path, "/swagger/") {
-				return true
-			}
-
-			return false
+			return strings.HasPrefix(c.Request().URL.Path, "/swagger/")
 		},
 	}))
 

--- a/backend/router.go
+++ b/backend/router.go
@@ -4,6 +4,7 @@ import (
 	"github.com/kingwrcy/moments/handler"
 	"github.com/kingwrcy/moments/vo"
 	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
 	"github.com/samber/do/v2"
 	echoSwagger "github.com/swaggo/echo-swagger"
 )
@@ -18,16 +19,16 @@ func setupRouter(injector do.Injector) {
 	e := do.MustInvoke[*echo.Echo](injector)
 	cfg := do.MustInvoke[*vo.AppConfig](injector)
 
-	api := e.Group("/api")
+	apiGroup := e.Group("/api")
 
-	userGroup := api.Group("/user")
+	userGroup := apiGroup.Group("/user")
 	userGroup.POST("/login", userHandler.Login)
 	userGroup.POST("/reg", userHandler.Reg)
 	userGroup.POST("/profile", userHandler.Profile)
 	userGroup.POST("/profile/:username", userHandler.ProfileForUser)
 	userGroup.POST("/saveProfile", userHandler.SaveProfile)
 
-	memoGroup := api.Group("/memo")
+	memoGroup := apiGroup.Group("/memo")
 	memoGroup.POST("/list", memoHandler.ListMemos)
 	memoGroup.POST("/save", memoHandler.SaveMemo)
 	memoGroup.POST("/remove", memoHandler.RemoveMemo)
@@ -39,19 +40,26 @@ func setupRouter(injector do.Injector) {
 	memoGroup.POST("/getDoubanBookInfo", memoHandler.GetDoubanBookInfo)
 	memoGroup.POST("/removeImage", memoHandler.RemoveImage)
 
-	commentGroup := api.Group("/comment")
+	commentGroup := apiGroup.Group("/comment")
 	commentGroup.POST("/add", commentHandler.AddComment)
 	commentGroup.POST("/remove", commentHandler.RemoveComment)
 
-	sycConfigGroup := api.Group("/sysConfig")
+	sycConfigGroup := apiGroup.Group("/sysConfig")
 	sycConfigGroup.POST("/save", sycConfigHandler.SaveConfig)
 	sycConfigGroup.POST("/get", sycConfigHandler.GetConfig)
 	sycConfigGroup.POST("/getFull", sycConfigHandler.GetFullConfig)
 
-	tagGroup := api.Group("/tag")
+	tagGroup := apiGroup.Group("/tag")
 	tagGroup.POST("/list", tagHandler.List)
 
-	e.GET("/upload/:filename", fileHandler.Get)
+	uploadGroup := e.Group("/upload")
+	uploadGroup.Use(middleware.StaticWithConfig(middleware.StaticConfig{
+		Root:       cfg.UploadDir,
+		HTML5:      false,
+		IgnoreBase: true,
+		Browse:     false,
+	}))
+
 	e.POST("/api/file/upload", fileHandler.Upload)
 	e.POST("/api/file/s3PreSigned", fileHandler.S3PreSigned)
 

--- a/backend/router.go
+++ b/backend/router.go
@@ -52,6 +52,10 @@ func setupRouter(injector do.Injector) {
 	tagGroup := apiGroup.Group("/tag")
 	tagGroup.POST("/list", tagHandler.List)
 
+	fileGroup := apiGroup.Group("/file")
+	fileGroup.POST("/upload", fileHandler.Upload)
+	fileGroup.POST("/s3PreSigned", fileHandler.S3PreSigned)
+
 	uploadGroup := e.Group("/upload")
 	uploadGroup.Use(middleware.StaticWithConfig(middleware.StaticConfig{
 		Root:       cfg.UploadDir,
@@ -59,9 +63,6 @@ func setupRouter(injector do.Injector) {
 		IgnoreBase: true,
 		Browse:     false,
 	}))
-
-	e.POST("/api/file/upload", fileHandler.Upload)
-	e.POST("/api/file/s3PreSigned", fileHandler.S3PreSigned)
 
 	if cfg.EnableSwagger {
 		e.GET("/swagger/*", echoSwagger.WrapHandler)


### PR DESCRIPTION
<!--

在创建 PR 前，请务必在右侧的 Labels 选项中添加以下 Label 中的一个:
- doc: 当前 PR 更新了文档
- bugfix: 当前 PR 修复了 bug
- feature: 当前 PR 添加了新功能
以便于自动生成 Release 时自动对 PR 进行归类。

在选择 Label 后，请在下方标题后填写当前 PR 的详细描述。

-->

### 这个 PR 做了什么？

目前实现的 `/upload` 接口没有正确处理 `..` 路径，使用以下命令可以访问 `uploadDir` 之外的文件，例如：

```bash
curl --path-as-is http://127.0.0.1:37892/upload/../../../../SOME_SECRET_FILE
```

使用 `middleware.StaticWithConfig` 中间件替换自己实现的文件接口。