### PR TITLE
修正 windows 平台的构建产物的文件名

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ LINUX_AMD64_BINARY_NAME := $(BINARY_NAME)-linux-amd64-$(VERSION)
 LINUX_ARM64_BINARY_NAME := $(BINARY_NAME)-linux-arm64-$(VERSION)
 DARWIN_AMD64_BINARY_NAME := $(BINARY_NAME)-darwin-amd64-$(VERSION)
 DARWIN_ARM64_BINARY_NAME := $(BINARY_NAME)-darwin-arm64-$(VERSION)
-WINDOWS_AMD64_BINARY_NAME := $(BINARY_NAME)-windows-amd64.exe-$(VERSION)
-WINDOWS_ARM64_BINARY_NAME := $(BINARY_NAME)-windows-arm64.exe-$(VERSION)
+WINDOWS_AMD64_BINARY_NAME := $(BINARY_NAME)-windows-amd64-$(VERSION).exe
+WINDOWS_ARM64_BINARY_NAME := $(BINARY_NAME)-windows-arm64-$(VERSION).exe
 
 BUILD_CMD_DEV := go build -ldflags="-X main.version=$(VERSION) -X main.commitId=$(COMMIT_ID)"
 BUILD_CMD_PROD := go build -tags prod -ldflags="-s -w -X main.version=$(VERSION) -X main.commitId=$(COMMIT_ID)"


### PR DESCRIPTION
<!--

在创建 PR 前，请务必在右侧的 Labels 选项中添加以下 Label 中的一个:
- doc: 当前 PR 更新了文档
- bugfix: 当前 PR 修复了 bug
- feature: 当前 PR 添加了新功能
以便于自动生成 Release 时自动对 PR 进行归类。

在选择 Label 后，请在下方标题后填写当前 PR 的详细描述。

-->

### 这个 PR 做了什么？

修复文件名：

`moments-windows-amd64.exe-0.2.7` -> `moments-windows-amd64-0.2.7.exe`