### PR TITLE
调整 memo 展示样式

### DIFF
--- a/front/assets/simple-markdown.scss
+++ b/front/assets/simple-markdown.scss
@@ -72,28 +72,94 @@
     overflow-wrap: break-word;
   }
 
-  h2, h3, h4, h5, h6 {
-    margin: 1rem 0;
+  p {
+    text-indent: 2em;
+    margin-bottom: 0.1rem;
+  }
+  pre p,
+  ul p,
+  ol p {
+    text-indent: 0 !important;
+    margin-bottom: inherit;
+}
+
+  h1 { font-size: 16px; } 
+  h2 { font-size: 15px; }
+  h3 { font-size: 14px; }
+  h4 { font-size: 13px; } 
+  h5 { font-size: 12px; }
+  h6 { font-size: 11px; }
+  h1, h2, h3, h4, h5, h6 {
+      margin-top: 0.8rem;
+      margin-bottom: 0.8rem;
+      line-height: 1;
   }
 
-  h2 {
-    font-size: 2rem;
-  }
+ table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1rem 0;
+  overflow-x: auto;
+  display: block;
+  background: white;
+}
+ th,
+ td {
+  padding: 8px 12px;
+  border: 1px solid #e2e8f0 !important; 
+}
+ th {
+  background-color: #f8fafc; 
+  font-weight: 600;
+}
 
-  h3 {
-    font-size: 1.8rem;
-  }
 
-  h4 {
-    font-size: 1.6rem;
-  }
+ blockquote {
+  border-left: 4px solid #42b883;
+  background: #f8f8f8;
+  padding: 0.4rem;
+  border-radius: 6px;
+  margin: 1rem 0;
+  box-shadow: none; 
+}
+ blockquote p {
+  margin: 0.2rem 0;
+  line-height: 1.7;
+}
 
-  h5 {
-    font-size: 1.4rem;
-  }
+ hr {
+  border: 0;
+  height: 2px;
+  margin: 0.7rem 0;
+  background: linear-gradient(
+    to right,
+    transparent,
+    #42b883,
+    transparent
+  );
+  position: relative;
+  overflow: visible;
+}
+  hr::after {
+  content: "";
+  position: absolute;
+  left: -100%;
+  top: -2px;
+  width: 50%;
+  height: 4px;
+  background: linear-gradient(
+    to right,
+    transparent,
+    rgba(255,255,255,0.8),
+    transparent
+  );
+  animation: hr-glow 3s ease-in-out infinite;
+}
 
-  h6 {
-    font-size: 1.2rem;
-  }
+@keyframes hr-glow {
+  0% { left: -100%; }
+  100% { left: 150%; }
+}
+
 
 }


### PR DESCRIPTION
markdown-it 的 css样式缺少几个，排版有些不方便。

新增了：

1. 段落首行缩进2个字符，p标签、引用标签缩进，其他如表格、代码块不缩进。

3. 仿照vue引用和分割线

4. 给表格增加线条，具有可观性，原来看不出是表格。

5. h1-h6标题重新修改字体大小，原来h6的字体都特别特别大。

![image](https://github.com/user-attachments/assets/4334b967-ca1b-4679-ab0b-0da9795911cc)



<!--

在创建 PR 前，请务必在右侧的 Labels 选项中添加以下 Label 中的一个:
- doc: 当前 PR 更新了文档
- bugfix: 当前 PR 修复了 bug
- feature: 当前 PR 添加了新功能
以便于自动生成 Release 时自动对 PR 进行归类。

在选择 Label 后，请在下方标题后填写当前 PR 的详细描述。

-->

### 这个 PR 做了什么？

