### PR TITLE
优化用户评论信息输入框，用户设置保存

### DIFF
--- a/front/components/CommentBox.vue
+++ b/front/components/CommentBox.vue
@@ -3,7 +3,7 @@
     <div class="relative">
       <UTextarea :rows="4" autofocus :placeholder="replyTo ? `回复给${replyTo}` : ''" v-model="state.content"/>
       <div class="flex gap-2 absolute right-3 bottom-2">
-        <UIcon v-if="!global.userinfo.token" class="text-[#9fc84a] w-6 h-6 animate-bounce cursor-pointer" name="i-carbon-user-avatar" @click="toggleUser"/>
+        <UIcon v-if="!global.userinfo.token" class="text-[#9fc84a] w-6 h-6 cursor-pointer" name="i-carbon-user-avatar" @click="toggleUser"/>
         <UIcon class="text-[#9fc84a] w-6 h-6 cursor-pointer select-none" name="i-carbon-face-satisfied" @click="toggleEmoji"/>
         <UButton class="cursor-pointer text-xs" color="white" @click="comment">发送</UButton>
       </div>

--- a/front/components/CommentBox.vue
+++ b/front/components/CommentBox.vue
@@ -1,18 +1,20 @@
 <template>
   <div class="px-4 py-2 flex flex-col gap-2 mt-2" v-if="currentCommentBox === pid">
     <div class="relative">
-      <UTextarea :rows="3" autofocus :placeholder="replyTo ? `回复给${replyTo}` : ''" v-model="state.content"/>
-      <div class="animate-bounce absolute right-2 bottom-1 cursor-pointer text-xl select-none" @click="toggleEmoji">😊
+      <UTextarea :rows="4" autofocus :placeholder="replyTo ? `回复给${replyTo}` : ''" v-model="state.content"/>
+      <div class="flex gap-2 absolute right-3 bottom-2">
+        <UIcon v-if="!global.userinfo.token" class="text-[#9fc84a] w-6 h-6 animate-bounce cursor-pointer" name="i-carbon-user-avatar" @click="toggleUser"/>
+        <UIcon class="text-[#9fc84a] w-6 h-6 cursor-pointer select-none" name="i-carbon-face-satisfied" @click="toggleEmoji"/>
+        <UButton class="cursor-pointer text-xs" color="white" @click="comment">发送</UButton>
       </div>
     </div>
     <Emoji v-if="emojiShow" @selected="emojiSelected"/>
-    <div class="flex gap-1">
+    <div v-if="userShow" class="flex gap-1">
       <template v-if="!global.userinfo.token">
         <UInput placeholder="姓名" v-model="state.username"/>
         <UInput placeholder="网站" v-model="state.website"/>
         <UInput placeholder="邮箱" v-model="state.email"/>
       </template>
-      <UButton color="white" @click="comment">发布评论</UButton>
     </div>
   </div>
 </template>
@@ -40,6 +42,7 @@ const localCommentUserinfo = useStorage('localCommentUserinfo', {
   website: "",
   email: "",
 })
+const userShow = ref(false)
 const emojiShow = ref(false)
 const currentCommentBox = useState('currentCommentBox')
 const sysConfig = useState<SysConfigVO>('sysConfig')
@@ -88,7 +91,9 @@ const doComment = async (token?: string) => {
   memoChangedEvent.emit(props.memoId)
 }
 
-
+const toggleUser = () => {
+  userShow.value = !userShow.value
+}
 const toggleEmoji = () => {
   emojiShow.value = !emojiShow.value
 }

--- a/front/components/MemoEdit.vue
+++ b/front/components/MemoEdit.vue
@@ -22,9 +22,7 @@
     <div class="w-full" @contextmenu.prevent="onContextMenu">
       <div class="relative">
         <UTextarea ref="contentRef" v-model="state.content" :rows="8" autoresize padded autofocus/>
-        <div class="animate-bounce absolute right-2 bottom-1 cursor-pointer text-xl select-none" @click="toggleEmoji">
-          😊
-        </div>
+        <UIcon class="text-[#9fc84a] w-6 h-6 animate-bounce absolute right-2 bottom-1 cursor-pointer select-none" name="i-carbon-face-satisfied" @click="toggleEmoji"/>
       </div>
 
       <Emoji v-if="emojiShow" @selected="emojiSelected" @close="emojiShow=false"/>

--- a/front/pages/user/settings.vue
+++ b/front/pages/user/settings.vue
@@ -66,7 +66,7 @@ const reload = async () => {
 const save = async () => {
   await useMyFetch('/user/saveProfile', state)
   toast.success("保存成功")
-  await reload()
+  location.reload()
 }
 
 const uploadAvatarUrl = async (files: FileList) => {


### PR DESCRIPTION
增加邮件通知后，用户信息输入框有姓名、网站和邮箱，显示效果不佳，优化后：
1. 用户信息输入框默认隐藏，未登录用户点击 跳动的头像 图标显示
2. 发布评论按钮更改为“发送”，与头像图标，emoji图标并排在一起
3. 用户设置保存成功刷新页面

> 默认显示
![image](https://github.com/user-attachments/assets/d1576983-bbd4-4e38-8c2c-162039b5f6d7)

> 点击头像后显示
![image](https://github.com/user-attachments/assets/8642a62b-03d6-4d95-aaea-4dc85f757898)

<!--

在创建 PR 前，请务必在右侧的 Labels 选项中添加以下 Label 中的一个:
- doc: 当前 PR 更新了文档
- bugfix: 当前 PR 修复了 bug
- feature: 当前 PR 添加了新功能
以便于自动生成 Release 时自动对 PR 进行归类。

在选择 Label 后，请在下方标题后填写当前 PR 的详细描述。

-->

### 这个 PR 做了什么？

