### PR TITLE
优化图片展示和上传

### DIFF
--- a/backend/db/memo.go
+++ b/backend/db/memo.go
@@ -2,29 +2,32 @@ package db
 
 import (
 	"time"
+
+	"github.com/kingwrcy/moments/vo"
 )
 
 type Memo struct {
-	Id              int32      `gorm:"column:id;primary_key;NOT NULL" json:"id,omitempty"`
-	Content         string     `gorm:"column:content" json:"content,omitempty"`
-	Imgs            string     `gorm:"column:imgs" json:"imgs,omitempty"`
-	FavCount        int32      `gorm:"column:favCount;default:0;NOT NULL" json:"favCount,omitempty"`
-	CommentCount    int32      `gorm:"column:commentCount;default:0;NOT NULL" json:"commentCount,omitempty"`
-	UserId          int32      `gorm:"column:userId;NOT NULL" json:"userId,omitempty"`
-	CreatedAt       *time.Time `gorm:"column:createdAt;default:CURRENT_TIMESTAMP;NOT NULL" json:"createdAt,omitempty"`
-	UpdatedAt       *time.Time `gorm:"column:updatedAt;NOT NULL" json:"updatedAt,omitempty"`
-	Music163Url     string     `gorm:"column:music163Url" json:"music163Url,omitempty"`
-	BilibiliUrl     string     `gorm:"column:bilibiliUrl" json:"bilibiliUrl,omitempty"`
-	Location        string     `gorm:"column:location" json:"location,omitempty"`
-	ExternalUrl     string     `gorm:"column:externalUrl" json:"externalUrl,omitempty"`
-	ExternalTitle   string     `gorm:"column:externalTitle" json:"externalTitle,omitempty"`
-	ExternalFavicon string     `gorm:"column:externalFavicon;default:/favicon.png;NOT NULL" json:"externalFavicon,omitempty"`
-	Pinned          *bool      `gorm:"column:pinned;default:false;NOT NULL" json:"pinned,omitempty"`
-	Ext             string     `gorm:"column:ext;default:{};NOT NULL" json:"ext,omitempty"`
-	ShowType        *int32     `gorm:"column:showType;default:1;NOT NULL" json:"showType,omitempty"`
-	User            *User      `json:"user,omitempty"`
-	Comments        []Comment  `json:"comments,omitempty"`
-	Tags            *string    `json:"tags,omitempty"`
+	Id              int32            `gorm:"column:id;primary_key;NOT NULL" json:"id,omitempty"`
+	Content         string           `gorm:"column:content" json:"content,omitempty"`
+	Imgs            string           `gorm:"column:imgs" json:"imgs,omitempty"`
+	FavCount        int32            `gorm:"column:favCount;default:0;NOT NULL" json:"favCount,omitempty"`
+	CommentCount    int32            `gorm:"column:commentCount;default:0;NOT NULL" json:"commentCount,omitempty"`
+	UserId          int32            `gorm:"column:userId;NOT NULL" json:"userId,omitempty"`
+	CreatedAt       *time.Time       `gorm:"column:createdAt;default:CURRENT_TIMESTAMP;NOT NULL" json:"createdAt,omitempty"`
+	UpdatedAt       *time.Time       `gorm:"column:updatedAt;NOT NULL" json:"updatedAt,omitempty"`
+	Music163Url     string           `gorm:"column:music163Url" json:"music163Url,omitempty"`
+	BilibiliUrl     string           `gorm:"column:bilibiliUrl" json:"bilibiliUrl,omitempty"`
+	Location        string           `gorm:"column:location" json:"location,omitempty"`
+	ExternalUrl     string           `gorm:"column:externalUrl" json:"externalUrl,omitempty"`
+	ExternalTitle   string           `gorm:"column:externalTitle" json:"externalTitle,omitempty"`
+	ExternalFavicon string           `gorm:"column:externalFavicon;default:/favicon.png;NOT NULL" json:"externalFavicon,omitempty"`
+	Pinned          *bool            `gorm:"column:pinned;default:false;NOT NULL" json:"pinned,omitempty"`
+	Ext             string           `gorm:"column:ext;default:{};NOT NULL" json:"ext,omitempty"`
+	ShowType        *int32           `gorm:"column:showType;default:1;NOT NULL" json:"showType,omitempty"`
+	User            *User            `json:"user,omitempty"`
+	Comments        []Comment        `json:"comments,omitempty"`
+	Tags            *string          `json:"tags,omitempty"`
+	ImgConfigs      *[]*vo.ImgConfig `gorm:"-" json:"imgConfigs,omitempty"`
 }
 
 func (m *Memo) TableName() string {

--- a/backend/handler/rss.go
+++ b/backend/handler/rss.go
@@ -150,9 +150,14 @@ func getContentWithExt(memo db.Memo, host string) string {
 	if memo.Imgs != "" {
 		imgs := strings.Split(memo.Imgs, ",")
 		for _, img := range imgs {
-			if img[:7] == "/upload" {
+			if img == "" {
+				continue
+			}
+
+			if strings.HasPrefix(img, "/upload/") {
 				img = host + img
 			}
+
 			content += fmt.Sprintf("\n\n![%s](%s)", img, img)
 		}
 	}

--- a/backend/vo/memo_vo.go
+++ b/backend/vo/memo_vo.go
@@ -75,3 +75,8 @@ type DoubanBook struct {
 	PubDate  string `json:"pubDate,omitempty"`  //发布日期
 	Keywords string `json:"keywords,omitempty"` //关键字
 }
+
+type ImgConfig struct {
+	Url      *string `json:"url,omitempty"`
+	ThumbUrl *string `json:"thumbUrl,omitempty"`
+}

--- a/front/components/Memo.vue
+++ b/front/components/Memo.vue
@@ -48,7 +48,7 @@
         <div class="flex flex-col gap-2">
           <external-url-preview :favicon="item.externalFavicon" :title="item.externalTitle" :url="item.externalUrl"
                                 v-if="item.externalFavicon&&item.externalTitle&&item.externalUrl"/>
-          <upload-image-preview :imgs="item.imgs||''" :memo-id="item.id"/>
+          <upload-image-preview :imgs="item.imgs" :imgConfigs="item.imgConfigs" :memo-id="item.id"/>
 
           <music-preview v-if="extJSON.music && extJSON.music.id" v-bind="extJSON.music"/>
           <douban-book-preview v-if="extJSON.doubanBook && extJSON.doubanBook.title" :book="extJSON.doubanBook"/>

--- a/front/components/MemoEdit.vue
+++ b/front/components/MemoEdit.vue
@@ -167,7 +167,7 @@ const locationLabel = computed(() => {
 })
 
 const handleDragImage = (imgs: string[]) => {
-  state.imgs = imgs.join(",")
+  state.imgs = imgs.filter(Boolean).join(",")
 }
 
 const updateMusic = (music: MusicDTO) => {
@@ -186,13 +186,10 @@ const {y: windowY} = useWindowScroll()
 const isOpen = ref(false)
 const virtualElement = ref({getBoundingClientRect: () => ({})})
 const handleRemoveImage = (img: string) => {
-  const imgs = state.imgs.split(",")
-  const index = imgs.findIndex(r => r === img)
-  if (index < 0) {
-    return
-  }
-  imgs.splice(index, 1)
-  state.imgs = imgs.join(",")
+  state.imgs = state.imgs
+    .split(",")
+    .filter(item => item && item != img)
+    .join(",")
 }
 
 function onContextMenu() {
@@ -278,9 +275,9 @@ const saveMemo = async () => {
     externalFavicon: state.externalUrl ? state.externalFavicon : "",
     externalTitle: state.externalTitle,
     externalUrl: state.externalUrl,
-    imgs: state.imgs.split(','),
+    imgs: state.imgs.split(",").filter(Boolean),
     location: state.location,
-    tags: selectedLabel.value
+    tags: selectedLabel.value,
   })
   toast.success("保存成功!")
   await navigateTo('/')

--- a/front/components/UploadImage.vue
+++ b/front/components/UploadImage.vue
@@ -1,15 +1,26 @@
 <template>
   <UPopover :popper="{ arrow: true }" mode="click">
-    <UIcon name="i-carbon-image" class="cursor-pointer w-6 h-6"/>
-    <template #panel="{close}">
+    <UIcon name="i-carbon-image" class="cursor-pointer w-6 h-6" />
+    <template #panel="{ close }">
       <div class="p-4 flex flex-col gap-2">
         <div class="text-xs text-gray-400">本地上传</div>
-        <UInput type="file" size="sm" icon="i-heroicons-folder" accept="image/*" @change="upload" multiple/>
-        <UTextarea :rows="5" placeholder="或者输入在线图片地址,逗号分隔,最多9张" v-model="imgs"/>
+        <UInput type="file" size="sm" icon="i-heroicons-folder" accept="image/*" @change="upload" multiple />
+
+        <template v-for="img, i in imgList" :key="img">
+          <div class="flex flex-wrap justify-between items-center">
+            <UInput class="flex-1 mr-[6px]" :modelValue="img" />
+            <UIcon name="i-heroicons-x-mark-16-solid" class="w-6 h-6" @click="removeImg(i)" />
+          </div>
+        </template>
+
+        <div class="flex flex-wrap justify-between items-center">
+          <UInput class="flex-1 mr-[6px]" v-model="imgUrlToAdd" />
+          <UIcon name="i-heroicons-plus-16-solid" class="w-6 h-6" @click="addImg" />
+        </div>
 
         <p v-if="filename" class="text-xs text-gray-400">正在上传({{ current }}/{{ total }})</p>
         <p v-if="filename" class="text-xs text-gray-400">{{ filename }}</p>
-        <UProgress :value="progress" v-if="progress > 0" indicator/>
+        <UProgress :value="progress" v-if="progress > 0" indicator />
 
         <UButtonGroup class="w-fit">
           <UButton @click="close()">确定</UButton>
@@ -21,14 +32,20 @@
 </template>
 
 <script setup lang="ts">
-import {useUpload} from "~/utils";
-import {toast} from "vue-sonner";
+import { useUpload } from "~/utils";
+import { toast } from "vue-sonner";
 
 const imgs = defineModel<string>('imgs')
 const progress = ref(0)
 const filename = ref('')
 const total = ref(0)
 const current = ref(0)
+const imgUrlToAdd = ref("")
+
+const imgList = computed(() => {
+  return imgs.value.split(',').filter(Boolean)
+})
+
 const upload = async (files: FileList) => {
   const containsOtherFile = [...files].some(file => !file.type.startsWith('image/'))
   if (containsOtherFile) {
@@ -48,12 +65,31 @@ const upload = async (files: FileList) => {
   }
 }
 
+const addImg = () => {
+  if (!imgUrlToAdd.value) {
+    return
+  }
+
+  const imgsArr = imgs.value.split(',').filter(Boolean)
+  if (imgsArr.includes(imgUrlToAdd.value)) {
+    toast.error("不能使用重复的图片地址");
+    return
+  }
+
+  imgs.value += `,${imgUrlToAdd.value}`
+  imgUrlToAdd.value = ''
+}
+
+const removeImg = (index) => {
+  const imgsArr = imgs.value.split(',').filter(Boolean)
+  imgsArr.splice(index, 1)
+  imgs.value = imgsArr.join(',')
+}
+
 const clear = (close: Function) => {
   imgs.value = ''
   close()
 }
 </script>
 
-<style scoped>
-
-</style>
+<style scoped></style>

--- a/front/pages/sys/settings.vue
+++ b/front/pages/sys/settings.vue
@@ -70,14 +70,17 @@
         <UToggle v-model="state.enableS3"/>
       </UFormGroup>
       <template v-if="state.enableS3">
-        <UFormGroup label="域名" name="domain" :ui="{label:{base:'font-bold'}}">
-          <UInput v-model="state.s3.domain"/>
+        <UFormGroup label="Bucket 域名（资源访问地址）" name="domain" :ui="{label:{base:'font-bold'}}">
+          <UInput v-model="state.s3.domain" placeholder="https://moments-test-bucket.oss-cn-hangzhou.aliyuncs.com" />
         </UFormGroup>
-        <UFormGroup label="桶名" name="bucket" :ui="{label:{base:'font-bold'}}">
-          <UInput v-model="state.s3.bucket"/>
+        <UFormGroup label="Endpoint 地址" name="endpoint" :ui="{label:{base:'font-bold'}}">
+          <UInput v-model="state.s3.endpoint" placeholder="https://oss-cn-hangzhou.aliyuncs.com" />
         </UFormGroup>
-        <UFormGroup label="地区" name="region" :ui="{label:{base:'font-bold'}}">
-          <UInput v-model="state.s3.region"/>
+        <UFormGroup label="Bucket 名称" name="bucket" :ui="{label:{base:'font-bold'}}">
+          <UInput v-model="state.s3.bucket" placeholder="moments-test-bucket" />
+        </UFormGroup>
+        <UFormGroup label="Bucket 地区" name="region" :ui="{label:{base:'font-bold'}}">
+          <UInput v-model="state.s3.region" placeholder="oss-cn-hangzhou" />
         </UFormGroup>
         <UFormGroup label="AccessKey" name="accessKey" :ui="{label:{base:'font-bold'}}">
           <UInput v-model="state.s3.accessKey"/>
@@ -85,10 +88,7 @@
         <UFormGroup label="SecretKey" name="secretKey" :ui="{label:{base:'font-bold'}}">
           <UInput v-model="state.s3.secretKey"/>
         </UFormGroup>
-        <UFormGroup label="S3 API接口地址" name="endpoint" :ui="{label:{base:'font-bold'}}">
-          <UInput v-model="state.s3.endpoint"/>
-        </UFormGroup>
-        <UFormGroup label="图片后缀" name="thumbnailSuffix" :ui="{label:{base:'font-bold'}}">
+        <UFormGroup label="图片后缀（在访问缩略图时会追加在图片地址后）" name="thumbnailSuffix" :ui="{label:{base:'font-bold'}}">
           <UInput v-model="state.s3.thumbnailSuffix"/>
         </UFormGroup>
       </template>


### PR DESCRIPTION
<!--

在创建 PR 前，请务必在右侧的 Labels 选项中添加以下 Label 中的一个:
- doc: 当前 PR 更新了文档
- bugfix: 当前 PR 修复了 bug
- feature: 当前 PR 添加了新功能
以便于自动生成 Release 时自动对 PR 进行归类。

在选择 Label 后，请在下方标题后填写当前 PR 的详细描述。

-->

### 这个 PR 做了什么？

fix #268 

优化图片展示和上传：

1. 只有上传到服务器的图片以及配置了 S3 请求后缀的情况下，才使用缩略图地址，避免发出无用的请求
2. 修改图片上传交互，把文本框替换为图片地址列表
3. 手动填写地址时，禁止填写重复的地址，否则对图片进行排序时会乱序（改起来太麻烦了，一般也不会写重复地址）

<img src="https://github.com/user-attachments/assets/c034e5f2-7b2a-4141-8acf-22e963505e8a" width="300px" />
