### PR TITLE
只在启用邮件通知时显示相关配置项

### DIFF
--- a/front/pages/sys/settings.vue
+++ b/front/pages/sys/settings.vue
@@ -95,6 +95,7 @@
       <UFormGroup label="是否启用邮件通知" name="enableEmail" :ui="{label:{base:'font-bold'}}">
       <UToggle v-model="state.enableEmail"/>
       </UFormGroup>
+      <template v-if="state.enableEmail">
       <UFormGroup label="smtp服务器" name="smtpHost" :ui="{label:{base:'font-bold'}}">
         <UInput v-model="state.smtpHost" placeholder="smtp.qq.com"/>
       </UFormGroup>
@@ -107,7 +108,8 @@
       <UFormGroup label="smtp密码/授权码" name="smtpPassword" :ui="{label:{base:'font-bold'}}">
         <UInput v-model="state.smtpPassword" type="password"/>
       </UFormGroup>
-
+      </template>
+    
     <UButton class="justify-center" @click="save">保存</UButton>
   </div>
 </template>


### PR DESCRIPTION
设置中，启用邮件通知时，下面的字段才会显示出来，和S3存储的设置行为一致。



