### PR TITLE
gorm实例复用导致sql污染

### DIFF
--- a/backend/handler/memo.go
+++ b/backend/handler/memo.go
@@ -171,7 +171,7 @@ func (m MemoHandler) ListMemos(c echo.Context) error {
 	_ = json.Unmarshal([]byte(sysConfig.Content), &sysConfigVO)
 	offset := (req.Page - 1) * req.Size
 
-	tx := m.base.db.Preload("User", func(x *gorm.DB) *gorm.DB {
+	tx := m.base.db.Model(&db.Memo{}).Preload("User", func(x *gorm.DB) *gorm.DB {
 		return x.Select("username", "nickname", "slogan", "id", "avatarUrl", "coverUrl")
 	})
 
@@ -212,8 +212,8 @@ func (m MemoHandler) ListMemos(c echo.Context) error {
 	if req.UserId != nil {
 		tx = tx.Where("userId = ?", req.UserId)
 	}
-	tx.Order("pinned desc, createdAt desc").Limit(req.Size).Offset(offset).Find(&list)
-	tx.Count(&total)
+	tx.Session(&gorm.Session{}).Order("pinned desc, createdAt desc").Limit(req.Size).Offset(offset).Find(&list)
+	tx.Session(&gorm.Session{}).Count(&total)
 
 	for i, memo := range list {
 		var comments []db.Comment


### PR DESCRIPTION
<!--

在创建 PR 前，请务必在右侧的 Labels 选项中添加以下 Label 中的一个:
- doc: 当前 PR 更新了文档
- bugfix: 当前 PR 修复了 bug
- feature: 当前 PR 添加了新功能
以便于自动生成 Release 时自动对 PR 进行归类。

在选择 Label 后，请在下方标题后填写当前 PR 的详细描述。

-->

### 这个 PR 做了什么？

在 #286 中删除了`totalCondition`，复用`tx`导致了sql污染，使后续的`tx.Count(&total)`无法正常获取total，进一步导致memo列表无法正常翻页。

关于gorm实例复用导致sql污染，详见[Reusability-and-Safety](https://gorm.io/docs/method_chaining.html#Reusability-and-Safety)。

将错误带入正式版本真的十分抱歉Orz

