### PR TITLE
增加一种用户主页布局，系统设置可切换

### DIFF
--- a/backend/vo/sysConfig_vo.go
+++ b/backend/vo/sysConfig_vo.go
@@ -13,6 +13,7 @@ type S3VO struct {
 type SysConfigVO struct {
 	EnableS3               bool   `json:"enableS3"`                   //是否启用S3
 	EnableAutoLoadNextPage bool   `json:"enableAutoLoadNextPage"`     //是否启用自动加载下一页
+	EnableNewMemo          bool   `json:"enableNewMemo"`              //用户主页是否切换列表布局
 	Favicon                string `json:"favicon,omitempty"`          //favicon
 	Title                  string `json:"title,omitempty"`            //标题
 	BeiAnNo                string `json:"beiAnNo,omitempty"`          //备案号码
@@ -36,6 +37,7 @@ type FullSysConfigVO struct {
 	AdminUserName          string `json:"adminUserName,omitempty"`    //管理员名称
 	EnableS3               bool   `json:"enableS3"`                   //是否启用S3
 	EnableAutoLoadNextPage bool   `json:"enableAutoLoadNextPage"`     //是否启用自动加载下一页
+	EnableNewMemo          bool   `json:"enableNewMemo"`              //用户主页是否切换列表布局
 	Favicon                string `json:"favicon,omitempty"`          //favicon
 	Title                  string `json:"title,omitempty"`            //标题
 	BeiAnNo                string `json:"beiAnNo,omitempty"`          //备案号码

--- a/front/components/MemoUser.vue
+++ b/front/components/MemoUser.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="flex flex-row text-sm w-full"
+    class="flex flex-row text-sm w-full hover:bg-slate-200 hover:dark:bg-neutral-700"
     :class="{ 'bg-slate-100 dark:bg-neutral-800': props.memo.pinned }"
   >
     <div class="flex flex-col w-24 pt-2">

--- a/front/components/MemoUser.vue
+++ b/front/components/MemoUser.vue
@@ -1,0 +1,184 @@
+<template>
+  <div
+    class="flex flex-row text-sm w-full"
+    :class="{ 'bg-slate-100 dark:bg-neutral-800': props.memo.pinned }"
+  >
+    <div class="flex flex-col w-24 pt-2">
+      <template v-if="!isPinned">
+        <div class="flex justify-center">
+          <span class="text-xl font-bold">{{
+            $dayjs(item.createdAt).format("DD")
+          }}</span>
+          <span class="flex items-end text-xs"
+            >{{ $dayjs(item.createdAt).format("MM") }}月</span
+          >
+        </div>
+        <div
+          class="flex justify-center text-[#576b95] font-medium dark:text-white text-xs mt-2 select-none"
+        >
+          {{ location }}
+        </div>
+      </template>
+      <div v-else class="flex justify-center items-center">
+        <span class="text-lg">置顶</span>
+      </div>
+    </div>
+    <div class="flex w-full flex-col pr-4 py-2">
+      <NuxtLink class="flex" :to="`/memo/${item.id}`">
+        <div
+          class="sm:w-24 sm:h-24 w-20 h-20 relative overflow-hidden"
+          v-if="imageCount > 0"
+        >
+          <div
+            :class="getImageGridClass(imageCount)"
+            class="h-full w-full gap-0.1 grid"
+          >
+            <div
+              v-for="(img, index) in images.slice(0, Math.min(imageCount, 9))"
+              :key="index"
+              :class="getGridClass(index, imageCount)"
+              class="border border-white dark:border-neutral-800 relative"
+            >
+              <img
+                :src="img"
+                class="absolute inset-0 w-full h-full object-cover"
+              />
+            </div>
+          </div>
+        </div>
+        <div class="flex-1 flex flex-col justify-between">
+          <div
+            class="markdown-content bg-neutral-100 dark:bg-neutral-800 p-2 !leading-7 line-clamp-2 sm:line-clamp-3"
+            v-if="imageCount === 0"
+            v-html="content"
+          ></div>
+          <div
+            class="markdown-content ml-1 !leading-5 line-clamp-2 sm:line-clamp-3"
+            v-if="imageCount > 0"
+            v-html="content"
+          ></div>
+          <div v-if="imageCount > 0" class="text-sm text-gray-500 ml-1">
+            有{{ imageCount }}图
+          </div>
+        </div>
+      </NuxtLink>
+      <div class="flex flex-col gap-2">
+        <external-url-preview
+          v-if="item.externalFavicon && item.externalTitle && item.externalUrl"
+          :favicon="item.externalFavicon"
+          :title="item.externalTitle"
+          :url="item.externalUrl"
+          class="pt-2"
+        />
+        <music-preview
+          v-if="extJSON.music && extJSON.music.id"
+          v-bind="extJSON.music"
+          class="pt-2"
+        />
+        <douban-book-preview
+          v-if="extJSON.doubanBook && extJSON.doubanBook.title"
+          :book="extJSON.doubanBook"
+          class="pt-2"
+        />
+        <douban-movie-preview
+          v-if="extJSON.doubanMovie && extJSON.doubanMovie.title"
+          :movie="extJSON.doubanMovie"
+          class="pt-2"
+        />
+        <video-preview-iframe
+          v-if="
+            extJSON.video &&
+            ['bilibili', 'youtube'].includes(extJSON.video.type) &&
+            extJSON.video.value
+          "
+          :url="extJSON.video.value"
+          class="pt-2"
+        />
+        <video-preview
+          v-if="
+            extJSON.video &&
+            extJSON.video.type === 'online' &&
+            extJSON.video.value
+          "
+          :url="extJSON.video.value"
+          class="pt-2"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { ExtDTO, MemoVO, SysConfigVO } from "~/types";
+import { md } from "~/utils";
+import { computed } from "vue";
+import { toast } from "vue-sonner";
+import { useRouter } from "vue-router";
+
+const router = useRouter();
+const sysConfig = useState<SysConfigVO>("sysConfig");
+const props = defineProps<{
+  memo: MemoVO;
+}>();
+
+const item = computed(() => props.memo);
+const isPinned = computed(() => item.value.pinned);
+const location = computed(() =>
+  (item.value.location || "").replaceAll(" ", " · ")
+);
+
+const extJSON = computed(() => {
+  try {
+    return JSON.parse(item.value.ext || "{}") as ExtDTO;
+  } catch (error) {
+    console.error("解析 ext 字段时出错:", error);
+    return {} as ExtDTO;
+  }
+});
+
+const content = computed(() => {
+  if (item.value.content && item.value.content.length > 0) {
+    try {
+      return md.render(item.value.content);
+    } catch (error) {
+      console.error("内容渲染错误，请重新编辑:", error);
+      toast.error("内容渲染错误，请重新编辑");
+      return "内容渲染错误，请重新编辑";
+    }
+  }
+  return "";
+});
+
+const imageCount = computed(() => {
+  const imgs = item.value.imgs || "";
+  return imgs.split(",").filter(Boolean).length;
+});
+
+const images = computed(() => {
+  const imgs = item.value.imgs || "";
+  return imgs.split(",").filter(Boolean);
+});
+
+const gridRules: Record<number, Record<number, string>> = {
+  2: {0: 'col-span-1', 1: 'col-span-1'},
+  3: {0: 'col-span-1', 1: 'col-span-1', 2: 'col-span-1'},
+  5: {0: 'col-span-2 row-span-2',1: 'col-span-1 row-span-2'},
+  6: {0: 'col-span-2 row-span-2'},
+  7: {0: 'col-span-1 row-span-2',1: 'col-span-1 row-span-2'},
+  8: {0: 'col-span-1 row-span-2'}
+} as const;
+
+const getImageGridClass = (count: number) => {
+  if (count <= 1) return '';
+  if (count === 2) return 'grid grid-cols-2';
+  if (count === 3) return 'grid grid-cols-3';
+  if (count <= 4) return 'grid grid-cols-2 grid-rows-2';
+  return 'grid grid-cols-3 grid-rows-3';
+};
+
+const getGridClass = (index: number, count: keyof typeof gridRules): string => {
+  return gridRules[count]?.[index] || '';
+};
+</script>
+
+<style scoped></style>

--- a/front/components/MemoUser.vue
+++ b/front/components/MemoUser.vue
@@ -48,7 +48,7 @@
         </div>
         <div class="flex-1 flex flex-col justify-between">
           <div
-            class="markdown-content bg-neutral-100 dark:bg-neutral-800 p-2 !leading-7 line-clamp-2 sm:line-clamp-3"
+            class="markdown-content bg-neutral-100 dark:bg-neutral-800 p-2 sm:pb-2 pb-1 !leading-7 line-clamp-2 sm:line-clamp-3"
             v-if="imageCount === 0"
             v-html="content"
           ></div>
@@ -161,7 +161,7 @@ const images = computed(() => {
 
 const gridRules: Record<number, Record<number, string>> = {
   2: {0: 'col-span-1', 1: 'col-span-1'},
-  3: {0: 'col-span-1', 1: 'col-span-1', 2: 'col-span-1'},
+  3: {0: 'row-span-2', 1: 'row-span-1', 2: 'row-span-1'},
   5: {0: 'col-span-2 row-span-2',1: 'col-span-1 row-span-2'},
   6: {0: 'col-span-2 row-span-2'},
   7: {0: 'col-span-1 row-span-2',1: 'col-span-1 row-span-2'},
@@ -171,7 +171,7 @@ const gridRules: Record<number, Record<number, string>> = {
 const getImageGridClass = (count: number) => {
   if (count <= 1) return '';
   if (count === 2) return 'grid grid-cols-2';
-  if (count === 3) return 'grid grid-cols-3';
+  if (count === 3) return 'grid grid-cols-2';
   if (count <= 4) return 'grid grid-cols-2 grid-rows-2';
   return 'grid grid-cols-3 grid-rows-3';
 };

--- a/front/components/MemoUser.vue
+++ b/front/components/MemoUser.vue
@@ -5,17 +5,11 @@
   >
     <div class="flex flex-col w-24 pt-2">
       <template v-if="!isPinned">
-        <div class="flex justify-center">
-          <span class="text-xl font-bold">{{
-            $dayjs(item.createdAt).format("DD")
-          }}</span>
-          <span class="flex items-end text-xs"
-            >{{ $dayjs(item.createdAt).format("MM") }}月</span
-          >
+        <div v-if="props.memo.displayDate" class="flex justify-center">
+          <span class="text-xl font-bold">{{ $dayjs(props.memo.createdAt).format("DD") }}</span>
+          <span class="flex items-end text-xs">{{ $dayjs(props.memo.createdAt).format("MM") }}月</span>
         </div>
-        <div
-          class="flex justify-center text-[#576b95] font-medium dark:text-white text-xs mt-2 select-none"
-        >
+        <div class="flex justify-center text-[#576b95] font-medium dark:text-white text-xs mt-2 select-none">
           {{ location }}
         </div>
       </template>

--- a/front/pages/sys/settings.vue
+++ b/front/pages/sys/settings.vue
@@ -21,6 +21,9 @@
     <UFormGroup label="首页是否自动加载下一页" name="enableAutoLoadNextPage" :ui="{label:{base:'font-bold'}}">
       <UToggle v-model="state.enableAutoLoadNextPage"/>
     </UFormGroup>
+    <UFormGroup label="用户主页是否切换列表布局" name="enableNewMemo" :ui="{label:{base:'font-bold'}}">
+      <UToggle v-model="state.enableNewMemo"/>
+    </UFormGroup>
     <UFormGroup label="是否启用评论" name="enableComment" :ui="{label:{base:'font-bold'}}">
       <UToggle v-model="state.enableComment"/>
     </UFormGroup>
@@ -127,6 +130,7 @@ const state = reactive({
   googleSiteKey:"",
   googleSecretKey:"",
   enableAutoLoadNextPage: true,
+  enableNewMemo: true,
   enableComment: true,
   enableRegister: true,
   maxCommentLength: 120,

--- a/front/pages/user/[id].vue
+++ b/front/pages/user/[id].vue
@@ -62,6 +62,7 @@ onMounted(async () => {
 });
 
 const reload = async () => {
+  state.page = 1;
   const res = await useMyFetch<{
     list: Array<MemoVO>;
     total: number;
@@ -75,12 +76,16 @@ const reload = async () => {
 };
 
 const loadMore = async () => {
-  state.page = state.page + 1;
+  const currentPage = state.page;
+  state.page = currentPage + 1;
   const res = await useMyFetch<{
     list: Array<MemoVO>;
     total: number;
     hasNext: boolean;
-  }>("/memo/list", state);
+  }>("/memo/list", {
+    ...state,
+    userId: parseInt(userId),
+  });
   memos.value = [...memos.value, ...res.list];
   hasNext.value = res.hasNext;
 };

--- a/front/pages/user/[id].vue
+++ b/front/pages/user/[id].vue
@@ -105,15 +105,27 @@ const nonPinnedMemos = computed(() =>
 const nonPinnedMemoList = computed(() => {
   if (!nonPinnedMemos.value.length) return [];
   let lastYear: string | null = null;
+  let lastDate: string | null = null;
   return nonPinnedMemos.value.map((memo) => {
     const currentYear = dayjs(memo.createdAt).locale("zh-cn").format("YYYY");
+    const currentDate = dayjs(memo.createdAt).locale("zh-cn").format("YYYY-MM-DD"); // 新增：当前日期
     let returns = memo;
+
     if (currentYear !== lastYear) {
       lastYear = currentYear;
       returns = Object.assign({}, returns, { displayYear: currentYear });
     } else {
       returns = Object.assign({}, returns, { displayYear: null });
     }
+
+    // 处理日期显示（仅当日期变化时标记显示）
+    if (currentDate !== lastDate) {
+      lastDate = currentDate;
+      returns = Object.assign({}, returns, { displayDate: currentDate });
+    } else {
+      returns = Object.assign({}, returns, { displayDate: null });
+    }
+
     return returns;
   });
 });

--- a/front/pages/user/[id].vue
+++ b/front/pages/user/[id].vue
@@ -1,13 +1,25 @@
 <template>
   <Header v-if="memos.length > 0" v-bind:user="memos[0].user" />
 
-  <div class="flex flex-col divide-y divide-[#C0BEBF]/20">
+  <div v-if="sysConfig.enableNewMemo" class="flex flex-col">
+    <div v-for="(memo, index) in pinnedMemos" :key="index">
+      <MemoUser v-bind:memo="memo" />
+    </div>
+    <div v-for="(memo, index) in nonPinnedMemoList" :key="index">
+      <div v-if="memo.displayYear" class="pl-4 py-4">
+        <span class="text-xl">{{ memo.displayYear }}</span>
+        <span class="text-sm">年</span>
+      </div>
+      <MemoUser v-bind:memo="memo" />
+    </div>
+  </div>
+  <div v-else class="flex flex-col divide-y divide-[#C0BEBF]/20">
     <Memo v-bind:memo="memo" v-for="memo in memos" :key="memo.id" />
   </div>
   <div
     v-if="hasNext"
     ref="loadMoreEle"
-    class="text-xs text-center text-gray-500 py-2"
+    class="text-xs text-center text-gray-500 py-2 cursor-pointer"
     @click="loadMore"
   >
     点击加载更多
@@ -18,17 +30,23 @@
 </template>
 
 <script setup lang="ts">
-import type { MemoVO } from "~/types";
+import type { MemoVO, SysConfigVO } from "~/types";
 import Memo from "~/components/Memo.vue";
+import MemoUser from "~/components/MemoUser.vue";
 import { memoChangedEvent, memoReloadEvent } from "~/event";
 import { useElementVisibility } from "@vueuse/core";
+import dayjs from "dayjs";
+
 const loadMoreEle = ref(null);
 const targetIsVisible = useElementVisibility(loadMoreEle);
+const sysConfig = useState<SysConfigVO>("sysConfig");
+
 watch(targetIsVisible, async (visible) => {
-  if (visible) {
+  if (visible && sysConfig.value?.enableAutoLoadNextPage) {
     await loadMore();
   }
 });
+
 const hasNext = ref(false);
 const route = useRoute();
 const userId = route.params.id as any as string;
@@ -38,6 +56,7 @@ const state = reactive({
 });
 
 const memos = ref<Array<MemoVO>>([]);
+
 onMounted(async () => {
   await reload();
 });
@@ -76,6 +95,27 @@ memoChangedEvent.on(async (id: number) => {
   if (index >= 0) {
     memos.value[index] = res;
   }
+});
+
+const pinnedMemos = computed(() => memos.value.filter((memo) => memo.pinned));
+const nonPinnedMemos = computed(() =>
+  memos.value.filter((memo) => !memo.pinned)
+);
+
+const nonPinnedMemoList = computed(() => {
+  if (!nonPinnedMemos.value.length) return [];
+  let lastYear: string | null = null;
+  return nonPinnedMemos.value.map((memo) => {
+    const currentYear = dayjs(memo.createdAt).locale("zh-cn").format("YYYY");
+    let returns = memo;
+    if (currentYear !== lastYear) {
+      lastYear = currentYear;
+      returns = Object.assign({}, returns, { displayYear: currentYear });
+    } else {
+      returns = Object.assign({}, returns, { displayYear: null });
+    }
+    return returns;
+  });
 });
 </script>
 

--- a/front/types/index.ts
+++ b/front/types/index.ts
@@ -41,6 +41,8 @@ export type  MemoVO = {
     user: UserVO,
     comments: Array<CommentVO>
     tags: string
+    displayYear?: string | null
+    displayDate?: string | null
 }
 
 export type UserVO = {

--- a/front/types/index.ts
+++ b/front/types/index.ts
@@ -63,6 +63,7 @@ export type SysConfigVO = {
     js: string,
     rss: string,
     enableAutoLoadNextPage: boolean
+	enableNewMemo: boolean
     enableS3: boolean
     enableRegister: boolean
     enableGoogleRecaptcha: boolean,


### PR DESCRIPTION
- 新布局特点：以年份分组显示列表，图片新布局，列表仅作展示

<!--

在创建 PR 前，请务必在右侧的 Labels 选项中添加以下 Label 中的一个:
- doc: 当前 PR 更新了文档
- bugfix: 当前 PR 修复了 bug
- feature: 当前 PR 添加了新功能
以便于自动生成 Release 时自动对 PR 进行归类。

在选择 Label 后，请在下方标题后填写当前 PR 的详细描述。

-->

### 这个 PR 做了什么？
新布局主要是展示用户的动态列表，点击列表可进入详情页。
新布局仿朋友圈个人相册页面，图片布局属于拼图模式
![image](https://github.com/user-attachments/assets/b513bfd7-f91a-41e4-bcbd-2e95d4bae2b9)

![{7EDB5455-28CB-4F94-B3A8-F59C697265B6}](https://github.com/user-attachments/assets/1519844e-1f7b-4e51-99db-82b1f3337d0f)
