### PR TITLE
区分访客与登录用户点赞操作

### DIFF
--- a/backend/db/comment.go
+++ b/backend/db/comment.go
@@ -16,6 +16,7 @@ type Comment struct {
 	CreatedAt *time.Time `gorm:"column:createdAt;default:CURRENT_TIMESTAMP;NOT NULL" json:"createdAt,omitempty"`
 	UpdatedAt *time.Time `gorm:"column:updatedAt;NOT NULL" json:"updatedAt,omitempty"`
 	MemoId    int32      `gorm:"column:memoId;NOT NULL" json:"memoId,omitempty"`
+	GuestID   string     `gorm:"column:guestId" json:"guestId,omitempty"`
 	Author    string     `gorm:"column:author" json:"author,omitempty"`
 	Memo      *Memo      `json:"memo,omitempty"`
 }

--- a/backend/db/db.go
+++ b/backend/db/db.go
@@ -79,7 +79,7 @@ func NewDB(injector do.Injector) (*gorm.DB, error) {
 	}
 
 	// 迁移 schema
-	err = db.AutoMigrate(&User{}, &Comment{}, &Memo{}, &SysConfig{}, &Friend{})
+	err = db.AutoMigrate(&User{}, &Comment{}, &Memo{}, &SysConfig{}, &Friend{}, &Like{})
 	if err != nil {
 		return nil, err
 	}

--- a/backend/db/like.go
+++ b/backend/db/like.go
@@ -1,0 +1,18 @@
+package db
+
+import (
+	"time"
+)
+
+type Like struct {
+	Id        int        `gorm:"column:id;primary_key;NOT NULL" json:"id,omitempty"`
+	MemoID    int        `gorm:"column:memoId;NOT NULL" json:"memoId,omitempty"`
+	UserID    *int       `gorm:"column:userId" json:"userId,omitempty"`
+	GuestID   string     `gorm:"column:guestId" json:"guestId,omitempty"`
+	GuestName string     `gorm:"column:guestName" json:"guestName,omitempty"`
+	CreatedAt *time.Time `gorm:"column:createdAt;default:CURRENT_TIMESTAMP;NOT NULL" json:"createdAt,omitempty"`
+}
+
+func (l *Like) TableName() string {
+	return "Like"
+}

--- a/backend/db/memo.go
+++ b/backend/db/memo.go
@@ -10,7 +10,6 @@ type Memo struct {
 	Id              int32            `gorm:"column:id;primary_key;NOT NULL" json:"id,omitempty"`
 	Content         string           `gorm:"column:content" json:"content,omitempty"`
 	Imgs            string           `gorm:"column:imgs" json:"imgs,omitempty"`
-	FavCount        int32            `gorm:"column:favCount;default:0;NOT NULL" json:"favCount,omitempty"`
 	CommentCount    int32            `gorm:"column:commentCount;default:0;NOT NULL" json:"commentCount,omitempty"`
 	UserId          int32            `gorm:"column:userId;NOT NULL" json:"userId,omitempty"`
 	CreatedAt       *time.Time       `gorm:"column:createdAt;default:CURRENT_TIMESTAMP;NOT NULL" json:"createdAt,omitempty"`

--- a/backend/handler/comment.go
+++ b/backend/handler/comment.go
@@ -118,7 +118,8 @@ func checkGoogleRecaptcha(logger zerolog.Logger, sysConfigVO vo.FullSysConfigVO,
 //	@Produce	json
 //	@Param		object	body	vo.AddCommentReq	true	"添加评论"
 //	@Success	200
-//	@Router		/api/comment/add [post]
+//
+// @Router		/api/comment/add [post]
 func (c CommentHandler) AddComment(ctx echo.Context) error {
 	var (
 		req         vo.AddCommentReq
@@ -145,8 +146,26 @@ func (c CommentHandler) AddComment(ctx echo.Context) error {
 	if context, ok := ctx.(CustomContext); ok {
 		currentUser := context.CurrentUser()
 		if currentUser == nil {
-			comment.Username = req.Username
+			if req.GuestID == "" {
+				return FailRespWithMsg(ctx, ParamError, "访客ID必填,请先登录或注册")
+			}
+			comment.GuestID = req.GuestID
+
+			if req.Username != "" {
+				// 检查访客是否输入了注册时相同的用户名，如果相同则在用户名后添加随机后缀
+				var userCount int64
+				c.base.db.Model(&db.User{}).Where("username = ? OR nickname = ?", req.Username, req.Username).Count(&userCount)
+				if userCount > 0 {
+					suffix := uuid.New().String()[:6]
+					req.Username = fmt.Sprintf("%s%s", req.Username, suffix)
+				}
+				comment.Username = req.Username
+			} else {
+				comment.Username = req.GuestID
+			}
+
 			comment.Email = req.Email
+			comment.Website = req.Website
 		} else {
 			comment.Username = currentUser.Nickname
 			comment.Email = currentUser.Email
@@ -154,51 +173,11 @@ func (c CommentHandler) AddComment(ctx echo.Context) error {
 		}
 	}
 
-	if comment.Username == "" {
-		// 尝试从 Cookie 中获取用户名
-		cookie, err := ctx.Cookie("anonymous_username")
-		var username string
-
-		if err != nil || cookie.Value == "" {
-			// 如果 Cookie 不存在，生成一个新的随机用户名
-			username = fmt.Sprintf("匿名用户_%s", uuid.New().String()[:4])
-			// 对用户名进行 URL 编码
-			encodedUsername := url.QueryEscape(username)
-			// 设置 Cookie，有效期 7 天
-			ctx.SetCookie(&http.Cookie{
-				Name:    "anonymous_username",
-				Value:   encodedUsername,
-				Path:    "/",
-				Expires: time.Now().Add(7 * 24 * time.Hour),
-			})
-		} else {
-			// 如果 Cookie 存在，使用之前的用户名
-			decodedUsername, err := url.QueryUnescape(cookie.Value)
-			if err != nil {
-				// 生成一个新的随机用户名
-				username = fmt.Sprintf("匿名用户_%s", uuid.New().String()[:4])
-				// 对用户名进行 URL 编码
-				encodedUsername := url.QueryEscape(username)
-				// 设置 Cookie，有效期 7 天
-				ctx.SetCookie(&http.Cookie{
-					Name:    "anonymous_username",
-					Value:   encodedUsername,
-					Path:    "/",
-					Expires: time.Now().Add(7 * 24 * time.Hour),
-				})
-			} else {
-				username = decodedUsername
-			}
-		}
-		comment.Username = username
-	}
-
 	comment.Content = req.Content
 	comment.CreatedAt = &now
 	comment.UpdatedAt = &now
 	comment.ReplyTo = req.ReplyTo
 	comment.ReplyEmail = req.ReplyEmail
-	comment.Website = req.Website
 	comment.MemoId = req.MemoID
 
 	if err = c.base.db.Save(&comment).Error; err == nil {

--- a/backend/handler/comment.go
+++ b/backend/handler/comment.go
@@ -11,10 +11,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/kingwrcy/moments/db"
-
 	"github.com/kingwrcy/moments/pkg/mail"
+	"github.com/kingwrcy/moments/pkg/util"
 	"github.com/kingwrcy/moments/vo"
 	"github.com/labstack/echo/v4"
 	"github.com/rs/zerolog"
@@ -146,21 +145,19 @@ func (c CommentHandler) AddComment(ctx echo.Context) error {
 	if context, ok := ctx.(CustomContext); ok {
 		currentUser := context.CurrentUser()
 		if currentUser == nil {
-			if req.GuestID == "" {
-				return FailRespWithMsg(ctx, ParamError, "访客ID必填,请先登录或注册")
+			if req.GuestID == "" || !util.IsGuestID(req.GuestID) {
+				return FailRespWithMsg(ctx, ParamError, "无效的访客ID")
 			}
 			comment.GuestID = req.GuestID
 
-			if req.Username != "" {
-				// 检查访客是否输入了注册时相同的用户名，如果相同则在用户名后添加随机后缀
-				var userCount int64
-				c.base.db.Model(&db.User{}).Where("username = ? OR nickname = ?", req.Username, req.Username).Count(&userCount)
-				if userCount > 0 {
-					suffix := uuid.New().String()[:6]
-					req.Username = fmt.Sprintf("%s%s", req.Username, suffix)
-				}
-				comment.Username = req.Username
-			} else {
+			// 使用统一的用户名处理逻辑
+			isConflict := func(name string) bool {
+				var count int64
+				c.base.db.Model(&db.User{}).Where("username = ? OR nickname = ?", name, name).Count(&count)
+				return count > 0
+			}
+			comment.Username = util.NormalizeUsername(req.Username, isConflict)
+			if comment.Username == "" {
 				comment.Username = req.GuestID
 			}
 
@@ -168,26 +165,26 @@ func (c CommentHandler) AddComment(ctx echo.Context) error {
 			comment.Website = req.Website
 
 			if req.Username != "" {
-			    // 获取该访客最新的评论姓名
-			    var latestComment db.Comment
-			    err := c.base.db.Where("guestId = ?", req.GuestID).
-			        Order("createdAt DESC").
-			        First(&latestComment).Error
+				// 获取该访客最新的评论姓名
+				var latestComment db.Comment
+				err := c.base.db.Where("guestId = ?", req.GuestID).
+					Order("createdAt DESC").
+					First(&latestComment).Error
 
-			    // 如果存在最新姓名，则使用该姓名更新所有记录
-			    if err == nil && latestComment.Username != "" {
-			        req.Username = latestComment.Username
-			    }
+				// 如果存在最新姓名，则使用该姓名更新所有记录
+				if err == nil && latestComment.Username != "" {
+					req.Username = latestComment.Username
+				}
 
-			    // 更新同访客ID的所有评论
-			    c.base.db.Model(&db.Comment{}).
-			        Where("guestId = ?", req.GuestID).
-			        Update("username", req.Username)
+				// 更新同访客ID的所有评论
+				c.base.db.Model(&db.Comment{}).
+					Where("guestId = ?", req.GuestID).
+					Update("username", req.Username)
 
-			    // 更新同访客ID的所有点赞
-			    c.base.db.Model(&db.Like{}).
-			        Where("guestId = ?", req.GuestID).
-			        Update("guestName", req.Username)
+				// 更新同访客ID的所有点赞
+				c.base.db.Model(&db.Like{}).
+					Where("guestId = ?", req.GuestID).
+					Update("guestName", req.Username)
 			}
 		} else {
 			comment.Username = currentUser.Nickname

--- a/backend/handler/comment.go
+++ b/backend/handler/comment.go
@@ -166,6 +166,29 @@ func (c CommentHandler) AddComment(ctx echo.Context) error {
 
 			comment.Email = req.Email
 			comment.Website = req.Website
+
+			if req.Username != "" {
+			    // 获取该访客最新的评论姓名
+			    var latestComment db.Comment
+			    err := c.base.db.Where("guestId = ?", req.GuestID).
+			        Order("createdAt DESC").
+			        First(&latestComment).Error
+
+			    // 如果存在最新姓名，则使用该姓名更新所有记录
+			    if err == nil && latestComment.Username != "" {
+			        req.Username = latestComment.Username
+			    }
+
+			    // 更新同访客ID的所有评论
+			    c.base.db.Model(&db.Comment{}).
+			        Where("guestId = ?", req.GuestID).
+			        Update("username", req.Username)
+
+			    // 更新同访客ID的所有点赞
+			    c.base.db.Model(&db.Like{}).
+			        Where("guestId = ?", req.GuestID).
+			        Update("guestName", req.Username)
+			}
 		} else {
 			comment.Username = currentUser.Nickname
 			comment.Email = currentUser.Email

--- a/backend/handler/like.go
+++ b/backend/handler/like.go
@@ -1,0 +1,302 @@
+package handler
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kingwrcy/moments/db"
+	"github.com/kingwrcy/moments/vo"
+	"github.com/labstack/echo/v4"
+	"github.com/samber/do/v2"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type LikeHandler struct {
+	base BaseHandler
+	hc   http.Client
+}
+
+func NewLikeHandler(injector do.Injector) *LikeHandler {
+	return &LikeHandler{
+		base: do.MustInvoke[BaseHandler](injector),
+		hc:   http.Client{},
+	}
+}
+
+// LikeMemo godoc
+//
+//	@Tags		Memo
+//	@Summary	点赞memo
+//	@Accept		json
+//	@Produce	json
+//	@Param		id	query	int	true	"memoID"
+//	@Success	200
+//
+// @Router /api/like/add [post]
+func (l LikeHandler) AddLike(c echo.Context) error {
+	var (
+		memo        db.Memo
+		like        db.Like
+		sysConfig   db.SysConfig
+		sysConfigVO vo.FullSysConfigVO
+		token       string
+	)
+
+	var currentMemo db.Memo
+	if err := l.base.db.Clauses(clause.Locking{Strength: "UPDATE"}).First(&currentMemo, c.QueryParam("id")).Error; err != nil {
+		l.base.log.Error().Err(err).Msg("获取memo记录失败")
+		return FailRespWithMsg(c, Fail, "系统繁忙，请稍后再试")
+	}
+	id, err := strconv.Atoi(c.QueryParam("id"))
+	if err != nil {
+		return FailResp(c, ParamError)
+	}
+
+	l.base.db.First(&sysConfig)
+	_ = json.Unmarshal([]byte(sysConfig.Content), &sysConfigVO)
+
+	if sysConfigVO.EnableGoogleRecaptcha {
+		token = c.QueryParam("token")
+		if token == "" {
+			return FailRespWithMsg(c, ParamError, "token不能为空")
+		}
+		if err := checkGoogleRecaptcha(l.base.log, sysConfigVO, token); err != nil {
+			return FailRespWithMsg(c, Fail, err.Error())
+		}
+	}
+
+	if err = l.base.db.First(&memo, id).Error; errors.Is(err, gorm.ErrRecordNotFound) {
+		return FailResp(c, ParamError)
+	}
+
+	ctx, ok := c.(CustomContext)
+	if !ok {
+		return FailResp(c, ParamError)
+	}
+	currentUser := (&ctx).CurrentUser()
+
+	var guestID string
+	var guestName string
+	if currentUser != nil {
+		userId := int(currentUser.Id)
+		if err = l.base.db.Where("memoId = ? AND userId = ?", id, userId).First(&like).Error; err == nil {
+			return FailRespWithMsg(c, Fail, "您已经点赞过了")
+		}
+		like = db.Like{
+			MemoID: id,
+			UserID: &userId,
+		}
+	} else {
+		guestID = c.QueryParam("guestId")
+		// 检查是否存在关联评论，如果存在则使用评论的用户名，否则使用guestID作为默认名称
+		var comment db.Comment
+		err := l.base.db.Where("guestId = ?", guestID).Order("createdAt DESC").First(&comment).Error
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				guestName = guestID
+			} else {
+				return FailRespWithMsg(c, Fail, "查询评论失败")
+			}
+		} else {
+			// 使用评论处理后的用户名
+			guestName = comment.Username
+		}
+		if err = l.base.db.Where("memoId = ? AND guestId = ?", id, guestID).First(&like).Error; err == nil {
+			return FailRespWithMsg(c, Fail, "您已经点赞过了")
+		}
+		like = db.Like{
+			MemoID:    id,
+			GuestID:   guestID,
+			GuestName: guestName,
+		}
+	}
+
+	tx := l.base.db.Begin()
+	if tx.Error != nil {
+		l.base.log.Error().Err(tx.Error).Msg("开启事务失败")
+		return FailRespWithMsg(c, Fail, "系统繁忙，请稍后再试")
+	}
+
+	if err = tx.Create(&like).Error; err != nil {
+		tx.Rollback()
+		return FailRespWithMsg(c, Fail, "点赞失败")
+	}
+
+	if err = tx.Commit().Error; err != nil {
+		return FailRespWithMsg(c, Fail, "提交事务失败")
+	}
+
+	return SuccessResp(c, h{})
+}
+
+// @Router /api/like/get [post]
+func (l LikeHandler) GetLike(c echo.Context) error {
+	var (
+		likes    []db.Like
+		users    []db.User
+		likeInfo []map[string]interface{}
+	)
+	id, err := strconv.Atoi(c.QueryParam("id"))
+	if err != nil {
+		return FailResp(c, ParamError)
+	}
+
+	if err = l.base.db.Where("memoId = ?", id).Find(&likes).Error; err != nil {
+		return FailRespWithMsg(c, Fail, "获取点赞信息失败")
+	}
+
+	userIDs := make([]int, 0)
+	for _, like := range likes {
+		if like.UserID != nil {
+			userIDs = append(userIDs, int(*like.UserID))
+		}
+	}
+	if len(userIDs) > 0 {
+		if err = l.base.db.Where("id IN ?", userIDs).Find(&users).Error; err != nil {
+			return FailRespWithMsg(c, Fail, "获取用户信息失败")
+		}
+	}
+
+	userMap := make(map[int]db.User)
+	for _, user := range users {
+		userMap[int(user.Id)] = user
+	}
+
+	for _, like := range likes {
+		info := make(map[string]interface{})
+		if like.UserID != nil {
+			user, ok := userMap[int(*like.UserID)]
+			if ok {
+				info["id"] = user.Id
+				info["name"] = user.Nickname
+			}
+		} else {
+			info["id"] = like.GuestID
+			info["name"] = like.GuestName
+		}
+		likeInfo = append(likeInfo, info)
+	}
+
+	result := h{
+		"likes": likeInfo,
+		"total": len(likes),
+	}
+
+	return SuccessResp(c, result)
+}
+
+// @Router /api/like/remove [post]
+func (l LikeHandler) RemoveLike(c echo.Context) error {
+	var (
+		like        db.Like
+		sysConfig   db.SysConfig
+		sysConfigVO vo.FullSysConfigVO
+		token       string
+	)
+
+	var currentMemo db.Memo
+	if err := l.base.db.Clauses(clause.Locking{Strength: "UPDATE"}).First(&currentMemo, c.QueryParam("id")).Error; err != nil {
+		l.base.log.Error().Err(err).Msg("获取memo记录失败")
+		return FailRespWithMsg(c, Fail, "系统繁忙，请稍后再试")
+	}
+	id, err := strconv.Atoi(c.QueryParam("id"))
+	if err != nil {
+		return FailResp(c, ParamError)
+	}
+
+	l.base.db.First(&sysConfig)
+	_ = json.Unmarshal([]byte(sysConfig.Content), &sysConfigVO)
+
+	if sysConfigVO.EnableGoogleRecaptcha {
+		token = c.QueryParam("token")
+		if token == "" {
+			return FailRespWithMsg(c, ParamError, "token不能为空")
+		}
+		if err := checkGoogleRecaptcha(l.base.log, sysConfigVO, token); err != nil {
+			return FailRespWithMsg(c, Fail, err.Error())
+		}
+	}
+
+	ctx, ok := c.(CustomContext)
+	if !ok {
+		return FailResp(c, ParamError)
+	}
+	currentUser := (&ctx).CurrentUser()
+
+	if currentUser != nil {
+		userId := int(currentUser.Id)
+		if err = l.base.db.Where("memoId = ? AND userId = ?", id, userId).First(&like).Error; errors.Is(err, gorm.ErrRecordNotFound) {
+			return FailRespWithMsg(c, Fail, "您还没有点赞过")
+		}
+	} else {
+		guestID := c.QueryParam("guestId")
+		if err = l.base.db.Where("memoId = ? AND guestId = ?", id, guestID).First(&like).Error; errors.Is(err, gorm.ErrRecordNotFound) {
+			return FailRespWithMsg(c, Fail, "您还没有点赞过")
+		}
+	}
+
+	tx := l.base.db.Begin()
+	if tx.Error != nil {
+		return FailRespWithMsg(c, Fail, "开启事务失败")
+	}
+
+	if err = tx.Delete(&like).Error; err != nil {
+		tx.Rollback()
+		return FailRespWithMsg(c, Fail, "取消点赞失败")
+	}
+
+	if err = tx.Commit().Error; err != nil {
+		return FailRespWithMsg(c, Fail, "提交事务失败")
+	}
+
+	return SuccessResp(c, h{})
+}
+
+// @Router /api/like/setGuestId [post]
+func (l LikeHandler) SetGuestId(c echo.Context) error {
+	cookie, err := c.Cookie("guestInfo")
+	if err == nil {
+		decodedValue, err := url.QueryUnescape(cookie.Value)
+		if err == nil {
+			var data vo.GuestInfo
+			if err := json.Unmarshal([]byte(decodedValue), &data); err == nil {
+				if time.Now().Unix()-data.TimeStamp < 7*24*60*60 {
+					return SuccessResp(c, data.GuestId)
+				}
+			}
+		}
+	}
+
+	newGuestId := fmt.Sprintf("访客%s", uuid.New().String()[:6])
+	data := vo.GuestInfo{
+		GuestId:   newGuestId,
+		TimeStamp: time.Now().Unix(),
+	}
+
+	// 将数据编码为 JSON 字符串，并将其转义以安全存储在 Cookie 中
+	cookieData, err := json.Marshal(data)
+	if err != nil {
+		l.base.log.Error().Msgf("Failed to marshal guest data: %v", err)
+	}
+
+	encodedValue := url.QueryEscape(string(cookieData))
+	secure := c.Scheme() == "https"
+	c.SetCookie(&http.Cookie{
+		Name:     "guestInfo",
+		Value:    encodedValue,
+		Path:     "/",
+		Expires:  time.Now().Add(7 * 24 * time.Hour),
+		Secure:   secure,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
+
+	return SuccessResp(c, newGuestId)
+}

--- a/backend/handler/like.go
+++ b/backend/handler/like.go
@@ -3,14 +3,13 @@ package handler
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/kingwrcy/moments/db"
+	"github.com/kingwrcy/moments/pkg/util"
 	"github.com/kingwrcy/moments/vo"
 	"github.com/labstack/echo/v4"
 	"github.com/samber/do/v2"
@@ -95,6 +94,9 @@ func (l LikeHandler) AddLike(c echo.Context) error {
 		}
 	} else {
 		guestID = c.QueryParam("guestId")
+		if !util.IsGuestID(guestID) {
+			return FailRespWithMsg(c, ParamError, "无效的访客ID")
+		}
 		// 检查是否存在关联评论，如果存在则使用评论的用户名，否则使用guestID作为默认名称
 		var comment db.Comment
 		err := l.base.db.Where("guestId = ?", guestID).Order("createdAt DESC").First(&comment).Error
@@ -274,7 +276,7 @@ func (l LikeHandler) SetGuestId(c echo.Context) error {
 		}
 	}
 
-	newGuestId := fmt.Sprintf("访客%s", uuid.New().String()[:6])
+	newGuestId := util.GenerateGuestID()
 	data := vo.GuestInfo{
 		GuestId:   newGuestId,
 		TimeStamp: time.Now().Unix(),

--- a/backend/handler/memo.go
+++ b/backend/handler/memo.go
@@ -280,49 +280,6 @@ func (m MemoHandler) RemoveMemo(c echo.Context) error {
 	return SuccessResp(c, h{})
 }
 
-// LikeMemo godoc
-//
-//	@Tags		Memo
-//	@Summary	点赞memo
-//	@Accept		json
-//	@Produce	json
-//	@Param		id	query	int	true	"memoID"
-//	@Success	200
-//	@Router		/api/memo/like [post]
-func (m MemoHandler) LikeMemo(c echo.Context) error {
-	var (
-		memo        db.Memo
-		sysConfig   db.SysConfig
-		sysConfigVO vo.FullSysConfigVO
-		token       string
-	)
-	id, err := strconv.Atoi(c.QueryParam("id"))
-	if err != nil {
-		return FailResp(c, ParamError)
-	}
-
-	m.base.db.First(&sysConfig)
-	_ = json.Unmarshal([]byte(sysConfig.Content), &sysConfigVO)
-
-	if sysConfigVO.EnableGoogleRecaptcha {
-		token = c.QueryParam("token")
-		if token == "" {
-			return FailRespWithMsg(c, ParamError, "token不能为空")
-		}
-		if err := checkGoogleRecaptcha(m.base.log, sysConfigVO, token); err != nil {
-			return FailRespWithMsg(c, Fail, err.Error())
-		}
-	}
-	if err = m.base.db.First(&memo, id).Error; errors.Is(err, gorm.ErrRecordNotFound) {
-		return FailResp(c, ParamError)
-	}
-	memo.FavCount = memo.FavCount + 1
-	if m.base.db.Updates(&memo).RowsAffected != 1 {
-		return FailRespWithMsg(c, Fail, "点赞失败")
-	}
-	return SuccessResp(c, h{})
-}
-
 // FindAndReplaceTags 处理 markdown 文本
 func FindAndReplaceTags(content string) (string, []string) {
 	// 定义正则表达式来匹配标签
@@ -396,7 +353,6 @@ func (m MemoHandler) SaveMemo(c echo.Context) error {
 	} else {
 		memo.CreatedAt = &now
 		memo.UserId = currentUser.Id
-		memo.FavCount = 0
 		memo.CommentCount = 0
 	}
 
@@ -622,270 +578,270 @@ func getFaviconAndTitle(websiteURL string) (string, string, error) {
 
 // GetDoubanMovieInfo godoc
 //
-//    @Tags       Memo
-//    @Summary    获取豆瓣电影详情
-//    @Accept     json
-//    @Produce    json
-//    @Param      id          query       int     true    "豆瓣电影ID"
-//    @Param      x-api-token header      string  true    "登录TOKEN"
-//    @Success    200         {object}    vo.DoubanMovie
-//    @Router     /api/memo/getDoubanMovieInfo [post]
+//	@Tags       Memo
+//	@Summary    获取豆瓣电影详情
+//	@Accept     json
+//	@Produce    json
+//	@Param      id          query       int     true    "豆瓣电影ID"
+//	@Param      x-api-token header      string  true    "登录TOKEN"
+//	@Success    200         {object}    vo.DoubanMovie
+//	@Router     /api/memo/getDoubanMovieInfo [post]
 func (m MemoHandler) GetDoubanMovieInfo(c echo.Context) error {
 
-    var (
-        book        vo.DoubanMovie
-        sysConfigVo vo.FullSysConfigVO
-        sysConfig   db.SysConfig
-        userAgent   = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3"
-    )
+	var (
+		book        vo.DoubanMovie
+		sysConfigVo vo.FullSysConfigVO
+		sysConfig   db.SysConfig
+		userAgent   = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3"
+	)
 
-    if err := m.base.db.First(&sysConfig).Error; errors.Is(err, gorm.ErrRecordNotFound) {
-        return FailRespWithMsg(c, Fail, "系统配置为空")
-    }
-    err := json.Unmarshal([]byte(sysConfig.Content), &sysConfigVo)
-    if err != nil {
-        return FailRespWithMsg(c, Fail, "读取系统配置异常")
-    }
+	if err := m.base.db.First(&sysConfig).Error; errors.Is(err, gorm.ErrRecordNotFound) {
+		return FailRespWithMsg(c, Fail, "系统配置为空")
+	}
+	err := json.Unmarshal([]byte(sysConfig.Content), &sysConfigVo)
+	if err != nil {
+		return FailRespWithMsg(c, Fail, "读取系统配置异常")
+	}
 
-    id := c.QueryParam("id")
-    target := fmt.Sprintf("https://movie.douban.com/subject/%s/", id)
+	id := c.QueryParam("id")
+	target := fmt.Sprintf("https://movie.douban.com/subject/%s/", id)
 
-    req, _ := http.NewRequest("GET", target, nil)
-    req.Header.Set("User-Agent", userAgent)
-    start := time.Now()
-    res, err := m.hc.Do(req)
-    m.base.log.Info().Str("豆瓣读书ID", id).Str("URL", target).Str("耗时", fmt.Sprintf("%f秒", time.Since(start).Seconds())).Msgf("获取豆瓣读书")
-    if err != nil {
-        m.base.log.Error().Msgf("获取豆瓣电影异常:%s", err.Error())
-        return FailRespWithMsg(c, Fail, err.Error())
-    }
-    defer res.Body.Close()
-    if res.StatusCode != 200 {
-        m.base.log.Error().Msgf("豆瓣电影API返回码不是200,而是:%d", res.StatusCode)
-        return FailRespWithMsg(c, Fail, fmt.Sprintf("豆瓣读书API返回码不是200,而是:%d,URL:%s", res.StatusCode, target))
-    }
+	req, _ := http.NewRequest("GET", target, nil)
+	req.Header.Set("User-Agent", userAgent)
+	start := time.Now()
+	res, err := m.hc.Do(req)
+	m.base.log.Info().Str("豆瓣读书ID", id).Str("URL", target).Str("耗时", fmt.Sprintf("%f秒", time.Since(start).Seconds())).Msgf("获取豆瓣读书")
+	if err != nil {
+		m.base.log.Error().Msgf("获取豆瓣电影异常:%s", err.Error())
+		return FailRespWithMsg(c, Fail, err.Error())
+	}
+	defer res.Body.Close()
+	if res.StatusCode != 200 {
+		m.base.log.Error().Msgf("豆瓣电影API返回码不是200,而是:%d", res.StatusCode)
+		return FailRespWithMsg(c, Fail, fmt.Sprintf("豆瓣读书API返回码不是200,而是:%d,URL:%s", res.StatusCode, target))
+	}
 
-    // Load the HTML document
-    doc, err := goquery.NewDocumentFromReader(res.Body)
-    if err != nil {
-        m.base.log.Error().Msgf("初始化html错误,%s", err.Error())
-        return FailRespWithMsg(c, Fail, fmt.Sprintf("初始化html错误,%s", err.Error()))
-    }
+	// Load the HTML document
+	doc, err := goquery.NewDocumentFromReader(res.Body)
+	if err != nil {
+		m.base.log.Error().Msgf("初始化html错误,%s", err.Error())
+		return FailRespWithMsg(c, Fail, fmt.Sprintf("初始化html错误,%s", err.Error()))
+	}
 
-    doc.Find("meta[property]").Each(func(i int, s *goquery.Selection) {
-        if properties, exists := s.Attr("property"); exists {
-            value := s.AttrOr("content", "")
-            if properties == "og:title" {
-                book.Title = value
-            } else if properties == "og:description" {
-                book.Desc = value
-            } else if properties == "og:image" {
-                book.Image = value
-            } else if properties == "video:director" {
-                book.Director = value
-            } else if properties == "video:actor" {
-                book.Actors = value + "/"
-            }
-        }
-    })
-    book.Url = target
-    book.ReleaseDate = doc.Find("span[property='v:initialReleaseDate']").AttrOr("content", "")
-    book.Runtime = doc.Find("span[property='v:runtime']").AttrOr("content", "")
-    book.Rating = doc.Find("strong.rating_num").Text()
-    if book.Rating == "" {
-        book.Rating = "未知评分"
-    }
+	doc.Find("meta[property]").Each(func(i int, s *goquery.Selection) {
+		if properties, exists := s.Attr("property"); exists {
+			value := s.AttrOr("content", "")
+			if properties == "og:title" {
+				book.Title = value
+			} else if properties == "og:description" {
+				book.Desc = value
+			} else if properties == "og:image" {
+				book.Image = value
+			} else if properties == "video:director" {
+				book.Director = value
+			} else if properties == "video:actor" {
+				book.Actors = value + "/"
+			}
+		}
+	})
+	book.Url = target
+	book.ReleaseDate = doc.Find("span[property='v:initialReleaseDate']").AttrOr("content", "")
+	book.Runtime = doc.Find("span[property='v:runtime']").AttrOr("content", "")
+	book.Rating = doc.Find("strong.rating_num").Text()
+	if book.Rating == "" {
+		book.Rating = "未知评分"
+	}
 
-    if !strings.HasPrefix(book.Image, "http") {
-        return FailRespWithMsg(c, Fail, "无法获取电影封面")
-    }
-    if sysConfigVo.EnableS3 {
-        cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion(sysConfigVo.S3.Region),
-            config.WithEndpointResolver(aws.EndpointResolverFunc(func(service, region string) (aws.Endpoint, error) {
-                return aws.Endpoint{URL: sysConfigVo.S3.Endpoint}, nil
-            })),
-            config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(sysConfigVo.S3.AccessKey, sysConfigVo.S3.SecretKey, "")))
-        if err != nil {
-            m.base.log.Error().Msgf("无法加载S3 SDK配置, %s", err)
-            return FailRespWithMsg(c, Fail, err.Error())
-        }
-        imageReq, _ := http.NewRequest("GET", book.Image, nil)
-        imageReq.Header.Set("User-Agent", userAgent)
-        imageResponse, err := m.hc.Do(imageReq)
-        if err != nil {
-            return FailRespWithMsg(c, Fail, fmt.Sprintf("下载豆瓣电影图片异常:%s", err.Error()))
-        }
-        defer imageResponse.Body.Close()
-        client := s3.NewFromConfig(cfg)
-        key := fmt.Sprintf("moments/%s/%s", time.Now().Format("2006/01/02"), strings.ReplaceAll(uuid.NewString(), "-", ""))
-        _, err = client.PutObject(context.TODO(), &s3.PutObjectInput{
-            Bucket: aws.String(sysConfigVo.S3.Bucket),
-            Key:    aws.String(key),
-            Body:   imageResponse.Body,
-        })
-        if err != nil {
-            return FailRespWithMsg(c, Fail, fmt.Sprintf("上传图片到s3异常:%s", err.Error()))
-        }
-        book.Image = fmt.Sprintf("%s/%s", sysConfigVo.S3.Domain, key)
-    } else {
-        image, err := downloadImage(book.Image, m.base.log, m.base.cfg)
-        if err != nil {
-            return FailRespWithMsg(c, Fail, fmt.Sprintf("下载豆瓣电影图片异常:%s", err.Error()))
-        }
-        book.Image = image
-    }
-    return SuccessResp(c, book)
+	if !strings.HasPrefix(book.Image, "http") {
+		return FailRespWithMsg(c, Fail, "无法获取电影封面")
+	}
+	if sysConfigVo.EnableS3 {
+		cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion(sysConfigVo.S3.Region),
+			config.WithEndpointResolver(aws.EndpointResolverFunc(func(service, region string) (aws.Endpoint, error) {
+				return aws.Endpoint{URL: sysConfigVo.S3.Endpoint}, nil
+			})),
+			config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(sysConfigVo.S3.AccessKey, sysConfigVo.S3.SecretKey, "")))
+		if err != nil {
+			m.base.log.Error().Msgf("无法加载S3 SDK配置, %s", err)
+			return FailRespWithMsg(c, Fail, err.Error())
+		}
+		imageReq, _ := http.NewRequest("GET", book.Image, nil)
+		imageReq.Header.Set("User-Agent", userAgent)
+		imageResponse, err := m.hc.Do(imageReq)
+		if err != nil {
+			return FailRespWithMsg(c, Fail, fmt.Sprintf("下载豆瓣电影图片异常:%s", err.Error()))
+		}
+		defer imageResponse.Body.Close()
+		client := s3.NewFromConfig(cfg)
+		key := fmt.Sprintf("moments/%s/%s", time.Now().Format("2006/01/02"), strings.ReplaceAll(uuid.NewString(), "-", ""))
+		_, err = client.PutObject(context.TODO(), &s3.PutObjectInput{
+			Bucket: aws.String(sysConfigVo.S3.Bucket),
+			Key:    aws.String(key),
+			Body:   imageResponse.Body,
+		})
+		if err != nil {
+			return FailRespWithMsg(c, Fail, fmt.Sprintf("上传图片到s3异常:%s", err.Error()))
+		}
+		book.Image = fmt.Sprintf("%s/%s", sysConfigVo.S3.Domain, key)
+	} else {
+		image, err := downloadImage(book.Image, m.base.log, m.base.cfg)
+		if err != nil {
+			return FailRespWithMsg(c, Fail, fmt.Sprintf("下载豆瓣电影图片异常:%s", err.Error()))
+		}
+		book.Image = image
+	}
+	return SuccessResp(c, book)
 }
 
 func downloadImage(src string, log zerolog.Logger, conf *vo.AppConfig) (string, error) {
-    start := time.Now()
-    client := &http.Client{}
-    req, _ := http.NewRequest("GET", src, nil)
-    req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3")
-    response, err := client.Do(req)
-    log.Info().Msgf("下载图片完成:%s,耗时:%f", src, time.Since(start).Seconds())
-    if err != nil {
-        return "", err
-    }
-    defer response.Body.Close()
+	start := time.Now()
+	client := &http.Client{}
+	req, _ := http.NewRequest("GET", src, nil)
+	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3")
+	response, err := client.Do(req)
+	log.Info().Msgf("下载图片完成:%s,耗时:%f", src, time.Since(start).Seconds())
+	if err != nil {
+		return "", err
+	}
+	defer response.Body.Close()
 
-    key := strings.ReplaceAll(uuid.NewString(), "-", "")
-    filepath := fmt.Sprintf("%s/%s.jpg", conf.UploadDir, key)
-    dst, err := os.Create(filepath)
-    log.Info().Msgf("保存图片到本地完成:%s,耗时:%f", src, time.Since(start).Seconds())
-    if err != nil {
-        log.Error().Msgf("打开目标图片异常:%s", err)
-        return "", err
-    }
-    defer dst.Close()
+	key := strings.ReplaceAll(uuid.NewString(), "-", "")
+	filepath := fmt.Sprintf("%s/%s.jpg", conf.UploadDir, key)
+	dst, err := os.Create(filepath)
+	log.Info().Msgf("保存图片到本地完成:%s,耗时:%f", src, time.Since(start).Seconds())
+	if err != nil {
+		log.Error().Msgf("打开目标图片异常:%s", err)
+		return "", err
+	}
+	defer dst.Close()
 
-    _, err = io.Copy(dst, response.Body)
-    log.Info().Msgf("保存图片到本地完成:%s,耗时:%f", src, time.Since(start).Seconds())
-    if err != nil {
-        return "", err
-    }
-    return fmt.Sprintf("/upload/%s.jpg", key), err
+	_, err = io.Copy(dst, response.Body)
+	log.Info().Msgf("保存图片到本地完成:%s,耗时:%f", src, time.Since(start).Seconds())
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("/upload/%s.jpg", key), err
 }
 
 // GetDoubanBookInfo godoc
 //
-//    @Tags       Memo
-//    @Summary    获取豆瓣读书详情
-//    @Accept     json
-//    @Produce    json
-//    @Param      id          query       int     true    "豆瓣读书ID"
-//    @Param      x-api-token header      string  true    "登录TOKEN"
-//    @Success    200         {object}    vo.DoubanBook
-//    @Router     /api/memo/getDoubanBookInfo [post]
+//	@Tags       Memo
+//	@Summary    获取豆瓣读书详情
+//	@Accept     json
+//	@Produce    json
+//	@Param      id          query       int     true    "豆瓣读书ID"
+//	@Param      x-api-token header      string  true    "登录TOKEN"
+//	@Success    200         {object}    vo.DoubanBook
+//	@Router     /api/memo/getDoubanBookInfo [post]
 func (m MemoHandler) GetDoubanBookInfo(c echo.Context) error {
 
-    var (
-        book        vo.DoubanBook
-        sysConfigVo vo.FullSysConfigVO
-        sysConfig   db.SysConfig
-        re          = regexp.MustCompile(`\d{4}-\d{1,2}(-\d{1,2})?`)
-        userAgent   = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3"
-    )
-    if err := m.base.db.First(&sysConfig).Error; errors.Is(err, gorm.ErrRecordNotFound) {
-        return FailRespWithMsg(c, Fail, "系统配置为空")
-    }
-    err := json.Unmarshal([]byte(sysConfig.Content), &sysConfigVo)
-    if err != nil {
-        return FailRespWithMsg(c, Fail, "读取系统配置异常")
-    }
+	var (
+		book        vo.DoubanBook
+		sysConfigVo vo.FullSysConfigVO
+		sysConfig   db.SysConfig
+		re          = regexp.MustCompile(`\d{4}-\d{1,2}(-\d{1,2})?`)
+		userAgent   = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3"
+	)
+	if err := m.base.db.First(&sysConfig).Error; errors.Is(err, gorm.ErrRecordNotFound) {
+		return FailRespWithMsg(c, Fail, "系统配置为空")
+	}
+	err := json.Unmarshal([]byte(sysConfig.Content), &sysConfigVo)
+	if err != nil {
+		return FailRespWithMsg(c, Fail, "读取系统配置异常")
+	}
 
-    id := c.QueryParam("id")
-    m.base.log.Info().Msgf("开始分析豆瓣图书,id:%s", id)
+	id := c.QueryParam("id")
+	m.base.log.Info().Msgf("开始分析豆瓣图书,id:%s", id)
 
-    target := fmt.Sprintf("https://book.douban.com/subject/%s/", id)
-    // Request the HTML page.
-    client := &http.Client{}
-    start := time.Now()
-    req, _ := http.NewRequest("GET", target, nil)
-    m.base.log.Info().Msgf("请求豆瓣读书地址:%s,耗时:%f秒", target, time.Since(start).Seconds())
-    req.Header.Set("User-Agent", userAgent)
-    res, err := client.Do(req)
-    if err != nil {
-        m.base.log.Error().Msgf("获取豆瓣读书异常:%s", err.Error())
-        return FailRespWithMsg(c, Fail, err.Error())
-    }
-    defer res.Body.Close()
-    if res.StatusCode != 200 {
-        m.base.log.Error().Msgf("豆瓣读书API返回码不是200,而是:%d", res.StatusCode)
-        return FailRespWithMsg(c, Fail, fmt.Sprintf("豆瓣读书API返回码不是200,而是:%d,URL:%s", res.StatusCode, target))
-    }
+	target := fmt.Sprintf("https://book.douban.com/subject/%s/", id)
+	// Request the HTML page.
+	client := &http.Client{}
+	start := time.Now()
+	req, _ := http.NewRequest("GET", target, nil)
+	m.base.log.Info().Msgf("请求豆瓣读书地址:%s,耗时:%f秒", target, time.Since(start).Seconds())
+	req.Header.Set("User-Agent", userAgent)
+	res, err := client.Do(req)
+	if err != nil {
+		m.base.log.Error().Msgf("获取豆瓣读书异常:%s", err.Error())
+		return FailRespWithMsg(c, Fail, err.Error())
+	}
+	defer res.Body.Close()
+	if res.StatusCode != 200 {
+		m.base.log.Error().Msgf("豆瓣读书API返回码不是200,而是:%d", res.StatusCode)
+		return FailRespWithMsg(c, Fail, fmt.Sprintf("豆瓣读书API返回码不是200,而是:%d,URL:%s", res.StatusCode, target))
+	}
 
-    // Load the HTML document
-    doc, err := goquery.NewDocumentFromReader(res.Body)
-    if err != nil {
-        m.base.log.Error().Msgf("初始化html错误,%s", err.Error())
-        return FailRespWithMsg(c, Fail, fmt.Sprintf("初始化html错误,%s", err.Error()))
-    }
+	// Load the HTML document
+	doc, err := goquery.NewDocumentFromReader(res.Body)
+	if err != nil {
+		m.base.log.Error().Msgf("初始化html错误,%s", err.Error())
+		return FailRespWithMsg(c, Fail, fmt.Sprintf("初始化html错误,%s", err.Error()))
+	}
 
-    doc.Find("meta[property]").Each(func(i int, s *goquery.Selection) {
-        if properties, exists := s.Attr("property"); exists {
-            value := s.AttrOr("content", "")
-            if properties == "og:title" {
-                book.Title = value
-            } else if properties == "og:description" {
-                book.Desc = value
-            } else if properties == "og:image" {
-                book.Image = value
-            } else if properties == "book:author" {
-                book.Author = value
-            } else if properties == "book:isbn" {
-                book.Isbn = value
-            }
-        }
-    })
-    book.Url = target
-    book.Keywords = doc.Find("meta[name='keywords']").AttrOr("content", "")
-    date := re.FindString(book.Keywords)
-    if date != "" {
-        book.PubDate = date
-    }
-    book.Rating = doc.Find("strong.rating_num").Text()
-    if strings.TrimSpace(book.Rating) == "" {
-        book.Rating = "暂无"
-    }
+	doc.Find("meta[property]").Each(func(i int, s *goquery.Selection) {
+		if properties, exists := s.Attr("property"); exists {
+			value := s.AttrOr("content", "")
+			if properties == "og:title" {
+				book.Title = value
+			} else if properties == "og:description" {
+				book.Desc = value
+			} else if properties == "og:image" {
+				book.Image = value
+			} else if properties == "book:author" {
+				book.Author = value
+			} else if properties == "book:isbn" {
+				book.Isbn = value
+			}
+		}
+	})
+	book.Url = target
+	book.Keywords = doc.Find("meta[name='keywords']").AttrOr("content", "")
+	date := re.FindString(book.Keywords)
+	if date != "" {
+		book.PubDate = date
+	}
+	book.Rating = doc.Find("strong.rating_num").Text()
+	if strings.TrimSpace(book.Rating) == "" {
+		book.Rating = "暂无"
+	}
 
-    if !strings.HasPrefix(book.Image, "http") {
-        return FailRespWithMsg(c, Fail, "无法获取图书封面")
-    }
-    if sysConfigVo.EnableS3 {
-        cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion(sysConfigVo.S3.Region),
-            config.WithEndpointResolver(aws.EndpointResolverFunc(func(service, region string) (aws.Endpoint, error) {
-                return aws.Endpoint{URL: sysConfigVo.S3.Endpoint}, nil
-            })),
-            config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(sysConfigVo.S3.AccessKey, sysConfigVo.S3.SecretKey, "")))
-        if err != nil {
-            m.base.log.Error().Msgf("无法加载S3 SDK配置, %s", err)
-            return FailRespWithMsg(c, Fail, err.Error())
-        }
-        imageReq, _ := http.NewRequest("GET", book.Image, nil)
-        imageReq.Header.Set("User-Agent", userAgent)
-        imageResponse, err := client.Do(imageReq)
-        if err != nil {
-            return FailRespWithMsg(c, Fail, fmt.Sprintf("下载豆瓣图片异常:%s", err.Error()))
-        }
-        defer imageResponse.Body.Close()
-        s3Client := s3.NewFromConfig(cfg)
-        key := fmt.Sprintf("moments/%s/%s", time.Now().Format("2006/01/02"), strings.ReplaceAll(uuid.NewString(), "-", ""))
-        _, err = s3Client.PutObject(context.TODO(), &s3.PutObjectInput{
-            Bucket: aws.String(sysConfigVo.S3.Bucket),
-            Key:    aws.String(key),
-            Body:   imageResponse.Body,
-        })
-        if err != nil {
-            return FailRespWithMsg(c, Fail, fmt.Sprintf("上传图片到s3异常:%s", err.Error()))
-        }
-        book.Image = fmt.Sprintf("%s/%s", sysConfigVo.S3.Domain, key)
-    } else {
-        image, err := downloadImage(book.Image, m.base.log, m.base.cfg)
-        if err != nil {
-            return FailRespWithMsg(c, Fail, fmt.Sprintf("下载豆瓣图片异常:%s", err.Error()))
-        }
-        book.Image = image
-    }
-    return SuccessResp(c, book)
+	if !strings.HasPrefix(book.Image, "http") {
+		return FailRespWithMsg(c, Fail, "无法获取图书封面")
+	}
+	if sysConfigVo.EnableS3 {
+		cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion(sysConfigVo.S3.Region),
+			config.WithEndpointResolver(aws.EndpointResolverFunc(func(service, region string) (aws.Endpoint, error) {
+				return aws.Endpoint{URL: sysConfigVo.S3.Endpoint}, nil
+			})),
+			config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(sysConfigVo.S3.AccessKey, sysConfigVo.S3.SecretKey, "")))
+		if err != nil {
+			m.base.log.Error().Msgf("无法加载S3 SDK配置, %s", err)
+			return FailRespWithMsg(c, Fail, err.Error())
+		}
+		imageReq, _ := http.NewRequest("GET", book.Image, nil)
+		imageReq.Header.Set("User-Agent", userAgent)
+		imageResponse, err := client.Do(imageReq)
+		if err != nil {
+			return FailRespWithMsg(c, Fail, fmt.Sprintf("下载豆瓣图片异常:%s", err.Error()))
+		}
+		defer imageResponse.Body.Close()
+		s3Client := s3.NewFromConfig(cfg)
+		key := fmt.Sprintf("moments/%s/%s", time.Now().Format("2006/01/02"), strings.ReplaceAll(uuid.NewString(), "-", ""))
+		_, err = s3Client.PutObject(context.TODO(), &s3.PutObjectInput{
+			Bucket: aws.String(sysConfigVo.S3.Bucket),
+			Key:    aws.String(key),
+			Body:   imageResponse.Body,
+		})
+		if err != nil {
+			return FailRespWithMsg(c, Fail, fmt.Sprintf("上传图片到s3异常:%s", err.Error()))
+		}
+		book.Image = fmt.Sprintf("%s/%s", sysConfigVo.S3.Domain, key)
+	} else {
+		image, err := downloadImage(book.Image, m.base.log, m.base.cfg)
+		if err != nil {
+			return FailRespWithMsg(c, Fail, fmt.Sprintf("下载豆瓣图片异常:%s", err.Error()))
+		}
+		book.Image = image
+	}
+	return SuccessResp(c, book)
 }

--- a/backend/handler/user.go
+++ b/backend/handler/user.go
@@ -203,6 +203,18 @@ func (u UserHandler) SaveProfile(c echo.Context) error {
 	user.CoverUrl = req.CoverUrl
 	user.Email = req.Email
 
+	// 同步更新用户的所有评论和点赞记录
+	if req.Nickname != "" {
+	    // 更新用户的所有评论
+	    u.base.db.Model(&db.Comment{}).
+	        Where("author = ?", currentUser.Id).
+	        Update("username", req.Nickname)
+
+	    // 更新用户的所有点赞
+	    u.base.db.Model(&db.Like{}).
+	        Where("userId = ?", currentUser.Id).
+	        Update("guestName", req.Nickname)
+	}
 	if err := u.base.db.Save(&user).Error; err != nil {
 		return FailResp(c, Fail)
 	}

--- a/backend/middleware/auth.go
+++ b/backend/middleware/auth.go
@@ -22,10 +22,12 @@ func Auth(injector do.Injector) echo.MiddlewareFunc {
 		"/api/memo/list",
 		"/api/user/profile",
 		"/api/sysConfig/get",
-		"/api/memo/like",
 		"/api/comment/add",
 		"/api/memo/get",
 		"/api/friend/list",
+		"/api/like/add",
+		"/api/like/get",
+		"/api/like/setGuestId",
 	}
 
 	return func(next echo.HandlerFunc) echo.HandlerFunc {

--- a/backend/pkg/util/guest.go
+++ b/backend/pkg/util/guest.go
@@ -1,0 +1,46 @@
+package util
+
+import (
+	"math/rand"
+	"strings"
+	"time"
+)
+
+const (
+	guestPrefix = "访客"
+	charset     = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+)
+
+var rng = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+// 生成访客ID，格式为"访客"+5位随机字母数字
+func GenerateGuestID() string {
+	b := make([]byte, 5)
+	for i := range b {
+		b[i] = charset[rng.Intn(len(charset))]
+	}
+	return guestPrefix + string(b)
+}
+
+// 检查是否是访客ID
+func IsGuestID(id string) bool {
+	return strings.HasPrefix(id, guestPrefix)
+}
+
+// 标准化用户名，处理冲突
+func NormalizeUsername(username string, isConflict func(string) bool) string {
+	if username == "" {
+		return ""
+	}
+
+	if !isConflict(username) {
+		return username
+	}
+
+	// 添加随机后缀解决冲突，使用5位随机字符保持统一
+	b := make([]byte, 5)
+	for i := range b {
+		b[i] = charset[rng.Intn(len(charset))]
+	}
+	return username + string(b)
+}

--- a/backend/router.go
+++ b/backend/router.go
@@ -13,6 +13,7 @@ func setupRouter(injector do.Injector) {
 	userHandler := handler.NewUserHandler(injector)
 	memoHandler := handler.NewMemoHandler(injector)
 	commentHandler := handler.NewCommentHandler(injector)
+	likeHandler := handler.NewLikeHandler(injector)
 	sycConfigHandler := handler.NewSysConfigHandler(injector)
 	fileHandler := handler.NewFileHandler(injector)
 	tagHandler := handler.NewTagHandler(injector)
@@ -33,7 +34,6 @@ func setupRouter(injector do.Injector) {
 	memoGroup.POST("/list", memoHandler.ListMemos)
 	memoGroup.POST("/save", memoHandler.SaveMemo)
 	memoGroup.POST("/remove", memoHandler.RemoveMemo)
-	memoGroup.POST("/like", memoHandler.LikeMemo)
 	memoGroup.POST("/get", memoHandler.GetMemo)
 	memoGroup.POST("/setPinned", memoHandler.SetPinned)
 	memoGroup.POST("/getFaviconAndTitle", memoHandler.GetFaviconAndTitle)
@@ -44,6 +44,12 @@ func setupRouter(injector do.Injector) {
 	commentGroup := apiGroup.Group("/comment")
 	commentGroup.POST("/add", commentHandler.AddComment)
 	commentGroup.POST("/remove", commentHandler.RemoveComment)
+
+	likeGroup := apiGroup.Group("/like")
+	likeGroup.POST("/add", likeHandler.AddLike)
+	likeGroup.POST("/remove", likeHandler.RemoveLike)
+	likeGroup.POST("/get", likeHandler.GetLike)
+	likeGroup.POST("/setGuestId", likeHandler.SetGuestId)
 
 	sycConfigGroup := apiGroup.Group("/sysConfig")
 	sycConfigGroup.POST("/save", sycConfigHandler.SaveConfig)

--- a/backend/vo/comment_vo.go
+++ b/backend/vo/comment_vo.go
@@ -8,6 +8,7 @@ type AddCommentReq struct {
 	Email      string `json:"email,omitempty"`      //作者邮箱
 	Website    string `json:"website,omitempty"`    //作者网站
 
-	MemoID int32  `json:"memoId,omitempty"` //回复的memoID
-	Token  string `json:"token,omitempty"`  //google recaptcha的token,开启的话必填
+	MemoID  int32  `json:"memoId,omitempty"`  //回复的memoID
+	GuestID string `json:"guestId,omitempty"` // 访客ID,未登录时才有效
+	Token   string `json:"token,omitempty"`   //google recaptcha的token,开启的话必填
 }

--- a/backend/vo/memo_vo.go
+++ b/backend/vo/memo_vo.go
@@ -80,3 +80,8 @@ type ImgConfig struct {
 	Url      *string `json:"url,omitempty"`
 	ThumbUrl *string `json:"thumbUrl,omitempty"`
 }
+
+type GuestInfo struct {
+    GuestId   string `json:"guestId,omitempty"`
+    TimeStamp int64  `json:"timestamp,omitempty"`
+}

--- a/front/components/Comment.vue
+++ b/front/components/Comment.vue
@@ -2,10 +2,12 @@
   <div>
     <span v-if="props.comment.author == props.memoUserId" class="text-[#576b95] text-nowrap">
       {{ props.comment.username }}
-      <UBadge color="gray" variant="solid" size="xs">作者</UBadge>
     </span>
     <span v-else class="text-[#576b95] text-nowrap">
-      <a v-if="props.comment.website" :href="formatWebsite(props.comment.website)" target="_blank">
+      <a v-if="props.comment.author" :href="`/user/${props.comment.author}`" target="_blank">
+        {{ props.comment.username }}
+      </a>
+      <a v-else-if="props.comment.website" :href="formatWebsite(props.comment.website)" target="_blank">
         {{ props.comment.username }}
       </a>
       <span v-else>{{ props.comment.username }}</span>
@@ -22,7 +24,7 @@
         <UIcon name="i-carbon-trash-can" class="cursor-pointer text-red-400"/>
       </Confirm>
     </span>
-    
+
   </div>
   <CommentBox :memo-id="props.memoId" :reply-to="props.comment.username" :comment-id="props.comment.id" :reply-email="props.comment.email"/>
 </template>

--- a/front/components/CommentBox.vue
+++ b/front/components/CommentBox.vue
@@ -26,6 +26,7 @@ import Emoji from "~/components/Emoji.vue";
 import {useGlobalState} from "~/store";
 import {useStorage} from '@vueuse/core'
 import type {SysConfigVO} from "~/types";
+import { getGuestId } from "~/utils";
 
 const props = defineProps<{
   commentId: number
@@ -56,8 +57,12 @@ const state = reactive({
   email: localCommentUserinfo.value.email,
 })
 
-
 const comment = async () => {
+  if (!state.content.trim()) {
+    toast.warning("发送失败，内容不能为空")
+    return
+  }
+
   if (sysConfig.value.enableGoogleRecaptcha) {
     grecaptcha.ready(() => {
       grecaptcha.execute(sysConfig.value.googleSiteKey, {action: 'newComment'}).then(async (token) => {
@@ -77,17 +82,18 @@ const doComment = async (token?: string) => {
       email: state.email,
     }
   }
+
   if (state.content.length > sysConfig.value.maxCommentLength) {
     toast.error("评论字数超过限制长度:" + sysConfig.value.maxCommentLength)
     return
   }
-  await useMyFetch(`/comment/add`, {...state, token:token})
+
+  const guestId = await getGuestId()
+  if (!guestId) return
+  await useMyFetch(`/comment/add`, {...state, token, guestId: guestId})
   toast.success("评论成功!")
   currentCommentBox.value = ''
-  state.username = ''
   state.content = ''
-  state.website = ''
-  state.email = ''
   memoChangedEvent.emit(props.memoId)
 }
 

--- a/front/components/Memo.vue
+++ b/front/components/Memo.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="$route.path === `/memo/${item.id}`" class="header relative mb-14">
+  <div v-if="isDetailPage" class="header relative mb-14">
     <div
       :class="{ 'bg-[#4c4c4c]/80 z-10': y > 100 }"
       class="flex fixed justify-between items-center p-4 w-full md:w-[567px] text-white top-0"
@@ -134,7 +134,7 @@
             }}
           </div>
           <div
-            @click="showToolbar = true"
+            @click="showToolbar = !showToolbar"
             class="toolbar-icon px-2 py-1 bg-[#f7f7f7] dark:bg-slate-700 hover:bg-[#dedede] cursor-pointer rounded flex items-center justify-center"
           >
             <img
@@ -151,13 +151,19 @@
             <div class="flex flex-row gap-2">
               <div
                 class="flex flex-row gap-1 cursor-pointer items-center px-4"
-                @click="likeMemo(item.id)"
+                @click="liked ? unlikeMemo(item.id) : likeMemo(item.id)"
               >
                 <UIcon
-                  name="i-carbon-favorite"
-                  :class="[liked ? 'text-red-400' : '']"
+                  v-if="liked"
+                  name="i-carbon-favorite-filled"
+                  class="w-4 h-4 text-red-400"
                 />
-                <div>赞</div>
+                <UIcon
+                  v-else
+                  name="i-carbon-favorite"
+                  class="w-4 h-4"
+                />
+                <div>{{ liked ? "取消" : "赞" }}</div>
               </div>
               <template v-if="sysConfig.enableComment">
                 <span class="bg-[#6b7280] h-[20px] w-[1px]"></span>
@@ -165,11 +171,11 @@
                   class="flex flex-row gap-1 cursor-pointer items-center px-4"
                   @click="doComment"
                 >
-                  <UIcon name="i-octicon-comment" />
+                  <UIcon name="i-octicon-comment" class="w-4 h-4 relative top-[2px]"/>
                   <div>评论</div>
                 </div>
               </template>
-              <template v-if="$route.path !== `/memo/${item.id}`">
+              <template v-if="!isDetailPage">
                 <span class="bg-[#6b7280] h-[20px] w-[1px]"></span>
                 <div
                   class="flex flex-row gap-1 cursor-pointer items-center px-4"
@@ -256,12 +262,28 @@
           class="rounded bottom-shadow bg-[#f7f7f7] dark:bg-[#202020] flex flex-col gap-1"
         >
           <div
-            v-if="item.favCount > 0"
+            v-if="likeInfo && likeInfo.length > 0"
             class="flex flex-row py-2 px-4 gap-2 items-center text-sm"
+            :class="[
+              item.comments && item.comments.length > 0
+                ? 'border-b-[1px] border-neutral-[100] dark:border-neutral-800'
+                : '',
+            ]"
           >
-            <UIcon name="i-carbon-favorite" class="text-red-500" />
-            <div class="text-[#576b95]">
-              <span class="mx-1">{{ item.favCount }}位访客</span>
+            <div class="text-[#576b95] gap-1">
+              <UIcon name="i-carbon-favorite" class="mr-1 relative top-[1px]" />
+              <!-- 显示点赞用户列表区域 -->
+              {{ (likeShowAll || isDetailPage ? likeInfo : likeInfo.slice(0, 3)).map(info => info.name || info.id).join(', ') }}
+                <span
+                v-if="!isDetailPage"
+                @click="likeShowAll = !likeShowAll" 
+                class="cursor-pointer"
+                >
+                <span v-if="likeNum > 3">
+                  <span v-if="likeShowAll" class="text-gray-400">[收起]</span>
+                  <span v-else>等{{ likeNum }}位称赞</span>
+                </span>
+              </span>
             </div>
           </div>
           <div class="flex flex-col gap-1" v-if="sysConfig.enableComment">
@@ -296,7 +318,8 @@ import { toast } from "vue-sonner";
 import { memoChangedEvent, memoReloadEvent } from "~/event";
 import Comment from "~/components/Comment.vue";
 import { useGlobalState } from "~/store";
-import { md } from "~/utils";
+import { md, getGuestId } from "~/utils";
+import {useStorage} from '@vueuse/core'
 
 const showMore = ref(false);
 const showMoreClicked = ref(false);
@@ -329,13 +352,15 @@ const item = computed(() => {
 });
 
 const global = useGlobalState();
-
 const moreToolbar = ref(false);
-
 const showToolbar = ref(false);
 const toolbarRef = ref(null);
-const liked = ref(false);
-onClickOutside(toolbarRef, () => (showToolbar.value = false));
+
+onClickOutside(toolbarRef, () =>
+  setTimeout(() => {
+    showToolbar.value = false;
+  }, 10)
+);
 
 const location = computed(() => {
   return (item.value.location || "").replaceAll(" ", " · ");
@@ -392,46 +417,160 @@ const setPinned = async (id: number) => {
   moreToolbar.value = false;
 };
 
-const doLike = async (id: number, token: string = "") => {
-  const likes = JSON.parse(
-    localStorage.getItem("likeMemos") || "[]"
-  ) as Array<number>;
-  await useMyFetch(`/memo/like?id=${id}&token=${token}`);
+const liked = ref(false);
+const likeInfo = ref<{ id: number | string; name: string }[] | null>(null);
+const likeNum = ref(0);
+const likeShowAll = ref(false);
+const isLoading = ref(false);
+const localCommentUserinfo = useStorage('localCommentUserinfo', {
+  username: "",
+  website: "",
+  email: "",
+})
+const doLike = async (params: string) => {
+  showToolbar.value = false;
+  try {
+    await useMyFetch(`/like/add?${params}`);
   toast.success("点赞成功!");
-  likes.push(id);
-  localStorage.setItem("likeMemos", JSON.stringify(likes));
-  memoChangedEvent.emit(id);
   liked.value = true;
+  } catch (error) {
+    console.error("点赞失败:", error);
+    toast.warning("点赞失败，请稍后重试！");
+  }
 };
 
 const likeMemo = async (id: number) => {
-  showToolbar.value = false;
-  const likes = JSON.parse(
-    localStorage.getItem("likeMemos") || "[]"
-  ) as Array<number>;
-  if (likes.includes(id)) {
-    toast.warning("您已经点赞过了!");
-    return;
-  }
+  if (isLoading.value) return;
+  isLoading.value = true;
+
+  try {
+    const guestId = await getGuestId();
+    if (!guestId) return;
+  let params = `id=${id}&guestId=${guestId}`;
+    const guestName = localCommentUserinfo.value.username;
+    if (guestName) {
+      params += `&guestName=${guestName}`;
+    }
 
   if (sysConfig.value.enableGoogleRecaptcha) {
+      await new Promise<void>((resolve) => {
     grecaptcha.ready(() => {
       grecaptcha
         .execute(sysConfig.value.googleSiteKey, { action: "newComment" })
         .then(async (token) => {
-          await doLike(id, token);
+          params += `&token=${token}`;
+          await doLike(params);
+              await getLike(id);
+              memoChangedEvent.emit(id);
+              resolve();
         });
     });
+      });
   } else {
-    await doLike(id);
+    await doLike(params);
+  await getLike(id);
+  memoChangedEvent.emit(id);
+    }
+  } finally {
+    isLoading.value = false;
   }
 };
 
-onMounted(() => {
-  const likes = JSON.parse(
-    localStorage.getItem("likeMemos") || "[]"
-  ) as Array<number>;
-  liked.value = likes.findIndex((r) => r === item.value.id) >= 0;
+const doUnlike = async (params: string) => {
+  showToolbar.value = false;
+  if (!global.value.userinfo.token) {
+    toast.warning("访客不允许取消点赞！");
+    return false;
+  }
+  try {
+    await useMyFetch(`/like/remove?${params}`);
+    toast.success("取消点赞成功!");
+    liked.value = false;
+    return true;
+  } catch (error) {
+    console.error("取消点赞失败:", error);
+    toast.warning("取消点赞失败，请稍后重试！");
+    return false;
+  }
+};
+
+const unlikeMemo = async (id: number) => {
+  if (isLoading.value) return;
+  isLoading.value = true;
+
+  try {
+    const guestId = await getGuestId();
+    if (!guestId) return;
+  let params = `id=${id}&guestId=${guestId}`;
+    const guestName = localCommentUserinfo.value.username;
+    if (guestName) {
+      params += `&guestName=${guestName}`;
+    }
+
+  if (sysConfig.value.enableGoogleRecaptcha) {
+      await new Promise<void>((resolve) => {
+    grecaptcha.ready(() => {
+      grecaptcha
+        .execute(sysConfig.value.googleSiteKey, { action: "newComment" })
+        .then(async (token) => {
+          params += `&token=${token}`;
+              const success = await doUnlike(params);
+              if (success) {
+                await getLike(id);
+                memoChangedEvent.emit(id);
+              }
+              resolve();
+        });
+    });
+      });
+  } else {
+      const success = await doUnlike(params);
+      if (success) {
+  await getLike(id);
+  memoChangedEvent.emit(id);
+      }
+    }
+  } finally {
+    isLoading.value = false;
+  }
+};
+
+const getLike = async (id: number) => {
+  const guestId = await getGuestId();
+  if (!guestId) return;
+  let params = `id=${id}&guestId=${guestId}`;
+
+  try {
+    const response = await useMyFetch<{
+      likes: { id: number | string; name: string }[];
+      total: number;
+    }>(`/like/get?${params}`);
+    likeInfo.value = (response.likes || []).sort((a, b) => {
+      return Number(typeof b.id === 'number') - Number(typeof a.id === 'number');
+    });
+    likeNum.value = response.total;
+    if (global.value.userinfo.token) {
+      const userId = global.value.userinfo.id;
+      liked.value = likeInfo.value?.some((info) => info.id === userId) || false;
+    } else {
+      const guestName = localCommentUserinfo.value.username;
+      if (guestName) {
+        liked.value = likeInfo.value?.some((info) => info.name === guestName) || false;
+      } else {
+        liked.value = likeInfo.value?.some((info) => info.id === guestId) || false; 
+      }
+    }
+    return true;
+  } catch (error) {
+    console.error("获取点赞信息失败:", error);
+    toast.error("获取点赞信息失败，请稍后重试！");
+    return false;
+  }
+};
+
+onMounted(async () => {
+  await getLike(item.value.id);
+
   if (!isDetailPage.value) {
     setTimeout(() => {
       const { height } = useElementSize(contentRef.value);

--- a/front/components/Memo.vue
+++ b/front/components/Memo.vue
@@ -553,13 +553,8 @@ const getLike = async (id: number) => {
       const userId = global.value.userinfo.id;
       liked.value = likeInfo.value?.some((info) => info.id === userId) || false;
     } else {
-      const guestName = localCommentUserinfo.value.username;
-      if (guestName) {
-        liked.value = likeInfo.value?.some((info) => info.name === guestName) || false;
-      } else {
         liked.value = likeInfo.value?.some((info) => info.id === guestId) || false; 
       }
-    }
     return true;
   } catch (error) {
     console.error("获取点赞信息失败:", error);

--- a/front/types/index.ts
+++ b/front/types/index.ts
@@ -28,7 +28,6 @@ export type  MemoVO = {
     content: string
     location: string
     imgs: string
-    favCount: number
     userId: number
     createdAt: string
     updatedAt: string

--- a/front/utils/index.ts
+++ b/front/utils/index.ts
@@ -223,3 +223,18 @@ createHighlighterCore({
     }),
   )
 })
+export const getGuestId = async () => {
+  const cachedGuestId = localStorage.getItem('guestId');
+  if (cachedGuestId) {
+    return cachedGuestId;
+  }
+
+  try {
+    const response = await useMyFetch<string>("/like/setGuestId");
+    localStorage.setItem('guestId', response);
+    return response;
+  } catch (error) {
+    toast.error("获取访客 ID 失败，请稍后重试！");
+    return null;
+  }
+};


### PR DESCRIPTION
<!--

在创建 PR 前，请务必在右侧的 Labels 选项中添加以下 Label 中的一个:
- doc: 当前 PR 更新了文档
- bugfix: 当前 PR 修复了 bug
- feature: 当前 PR 添加了新功能
以便于自动生成 Release 时自动对 PR 进行归类。

在选择 Label 后，请在下方标题后填写当前 PR 的详细描述。

-->

### 这个 PR 做了什么？

- 访客仅支持点赞，不允许取消
- 登录用户支持点赞和取消点赞
- 点赞时优先使用访客评论填写的姓名，没有则使用随机生成的访客ID（全局统一，确保评论与点赞一致）
- 点赞用户列表，默认显示3个，支持展开收起

测试镜像地址： `dinphy/moments:v0.7.1`

![屏幕截图 2025-06-09 180626](https://github.com/user-attachments/assets/1dcd23ef-19cb-439a-8982-d0e5f1b7ba1e)
![屏幕截图 2025-06-09 180646](https://github.com/user-attachments/assets/72d48859-9f6e-48e0-84e9-ac7304fb39c9)

[功能需求：点赞增加取消和显示用户名称](https://github.com/kingwrcy/moments/issues/326)
[现在所有人都看不到谁点了赞，希望和微信一样能看到点赞人的名字](https://github.com/kingwrcy/moments/issues/267)